### PR TITLE
Add `ExplicitOnly` configuration option to `FactoryBot/ConsistentParenthesesStyle`, `FactoryBot/CreateList` and `FactoryBot/FactoryNameStyle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `FactoryBot/RedundantFactoryOption` cop. ([@r7kamura])
 - Add `ExplicitOnly` configuration option to `FactoryBot/ConsistentParenthesesStyle`. ([@ydah])
 - Add `ExplicitOnly` configuration option to `FactoryBot/ConsistentParenthesesStyle` and `FactoryBot/CreateList`. ([@ydah])
+- Add `ExplicitOnly` configuration option to `FactoryBot/ConsistentParenthesesStyle`, `FactoryBot/CreateList` and `FactoryBot/FactoryNameStyle`. ([@ydah])
 
 ## 2.22.0 (2023-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Mark `FactoryBot/CreateList` as `SafeAutoCorrect: false`. ([@r7kamura])
 - Change `FactoryBot/CreateList` so that it considers `times.map`. ([@r7kamura])
 - Add `FactoryBot/RedundantFactoryOption` cop. ([@r7kamura])
-
 - Add `ExplicitOnly` configuration option to `FactoryBot/ConsistentParenthesesStyle`. ([@ydah])
+- Add `ExplicitOnly` configuration option to `FactoryBot/ConsistentParenthesesStyle` and `FactoryBot/CreateList`. ([@ydah])
 
 ## 2.22.0 (2023-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Change `FactoryBot/CreateList` so that it considers `times.map`. ([@r7kamura])
 - Add `FactoryBot/RedundantFactoryOption` cop. ([@r7kamura])
 
+- Add `ExplicitOnly` configuration option to `FactoryBot/ConsistentParenthesesStyle`. ([@ydah])
+
 ## 2.22.0 (2023-05-04)
 
 - Extracted from `rubocop-rspec` into a separate repository for easier use with Minitest/Cucumber. ([@ydah])

--- a/config/default.yml
+++ b/config/default.yml
@@ -44,6 +44,7 @@ FactoryBot/CreateList:
   SupportedStyles:
     - create_list
     - n_times
+  ExplicitOnly: false
   SafeAutoCorrect: false
   VersionAdded: '1.25'
   VersionChanged: "<<next>>"

--- a/config/default.yml
+++ b/config/default.yml
@@ -26,7 +26,9 @@ FactoryBot/ConsistentParenthesesStyle:
   SupportedStyles:
     - require_parentheses
     - omit_parentheses
+  ExplicitOnly: false
   VersionAdded: '2.14'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/ConsistentParenthesesStyle
 
 FactoryBot/CreateList:

--- a/config/default.yml
+++ b/config/default.yml
@@ -64,11 +64,13 @@ FactoryBot/FactoryClassName:
 FactoryBot/FactoryNameStyle:
   Description: Checks for name style for argument of FactoryBot::Syntax::Methods.
   Enabled: pending
-  VersionAdded: '2.16'
   EnforcedStyle: symbol
   SupportedStyles:
     - symbol
     - string
+  ExplicitOnly: false
+  VersionAdded: '2.16'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/FactoryNameStyle
 
 FactoryBot/RedundantFactoryOption:

--- a/docs/modules/ROOT/pages/cops_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_factorybot.adoc
@@ -60,7 +60,7 @@ count { 1 }
 | Yes
 | Yes
 | 2.14
-| -
+| <<next>>
 |===
 
 Use a consistent style for parentheses in factory_bot calls.
@@ -103,6 +103,34 @@ build(
 )
 ----
 
+==== `ExplicitOnly: false` (default)
+
+[source,ruby]
+----
+# bad - with `EnforcedStyle: require_parentheses`
+FactoryBot.create :user
+build :user
+
+# good - with `EnforcedStyle: require_parentheses`
+FactoryBot.create(:user)
+build(:user)
+----
+
+==== `ExplicitOnly: true`
+
+[source,ruby]
+----
+# bad - with `EnforcedStyle: require_parentheses`
+FactoryBot.create :user
+FactoryBot.build :user
+
+# good - with `EnforcedStyle: require_parentheses`
+FactoryBot.create(:user)
+FactoryBot.build(:user)
+create :user
+build :user
+----
+
 === Configurable attributes
 
 |===
@@ -111,6 +139,10 @@ build(
 | EnforcedStyle
 | `require_parentheses`
 | `require_parentheses`, `omit_parentheses`
+
+| ExplicitOnly
+| `false`
+| Boolean
 |===
 
 === References

--- a/docs/modules/ROOT/pages/cops_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_factorybot.adoc
@@ -205,6 +205,32 @@ create_list :user, 3
 3.times.map { create :user }
 ----
 
+==== `ExplicitOnly: false` (default)
+
+[source,ruby]
+----
+# bad - with `EnforcedStyle: create_list`
+3.times { FactoryBot.create :user }
+3.times { create :user }
+
+# good - with `EnforcedStyle: create_list`
+FactoryBot.create_list :user, 3
+create_list :user, 3
+----
+
+==== `ExplicitOnly: true`
+
+[source,ruby]
+----
+# bad - with `EnforcedStyle: create_list`
+3.times { FactoryBot.create :user }
+
+# good - with `EnforcedStyle: create_list`
+FactoryBot.create_list :user, 3
+create_list :user, 3
+3.times { create :user }
+----
+
 === Configurable attributes
 
 |===
@@ -217,6 +243,10 @@ create_list :user, 3
 | EnforcedStyle
 | `create_list`
 | `create_list`, `n_times`
+
+| ExplicitOnly
+| `false`
+| Boolean
 |===
 
 === References

--- a/docs/modules/ROOT/pages/cops_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_factorybot.adoc
@@ -308,7 +308,7 @@ end
 | Yes
 | Yes
 | 2.16
-| -
+| <<next>>
 |===
 
 Checks for name style for argument of FactoryBot::Syntax::Methods.
@@ -341,6 +341,34 @@ create('user')
 build "user", username: "NAME"
 ----
 
+==== `ExplicitOnly: false` (default)
+
+[source,ruby]
+----
+# bad - with `EnforcedStyle: symbol`
+FactoryBot.create('user')
+create('user')
+
+# good - with `EnforcedStyle: symbol`
+FactoryBot.create(:user)
+create(:user)
+----
+
+==== `ExplicitOnly: true`
+
+[source,ruby]
+----
+# bad - with `EnforcedStyle: symbol`
+FactoryBot.create(:user)
+FactoryBot.build "user", username: "NAME"
+
+# good - with `EnforcedStyle: symbol`
+FactoryBot.create('user')
+FactoryBot.build "user", username: "NAME"
+FactoryBot.create(:user)
+create(:user)
+----
+
 === Configurable attributes
 
 |===
@@ -349,6 +377,10 @@ build "user", username: "NAME"
 | EnforcedStyle
 | `symbol`
 | `symbol`, `string`
+
+| ExplicitOnly
+| `false`
+| Boolean
 |===
 
 === References

--- a/lib/rubocop-factory_bot.rb
+++ b/lib/rubocop-factory_bot.rb
@@ -8,6 +8,8 @@ require 'rubocop'
 require_relative 'rubocop/factory_bot/factory_bot'
 require_relative 'rubocop/factory_bot/language'
 
+require_relative 'rubocop/cop/factory_bot/mixin/configurable_explicit_only'
+
 require_relative 'rubocop/cop/factory_bot_cops'
 
 project_root = File.join(__dir__, '..')

--- a/lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb
+++ b/lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb
@@ -35,49 +35,67 @@ module RuboCop
       #     name: 'foo'
       #   )
       #
+      # @example `ExplicitOnly: false` (default)
+      #
+      #   # bad - with `EnforcedStyle: require_parentheses`
+      #   FactoryBot.create :user
+      #   build :user
+      #
+      #   # good - with `EnforcedStyle: require_parentheses`
+      #   FactoryBot.create(:user)
+      #   build(:user)
+      #
+      # @example `ExplicitOnly: true`
+      #
+      #   # bad - with `EnforcedStyle: require_parentheses`
+      #   FactoryBot.create :user
+      #   FactoryBot.build :user
+      #
+      #   # good - with `EnforcedStyle: require_parentheses`
+      #   FactoryBot.create(:user)
+      #   FactoryBot.build(:user)
+      #   create :user
+      #   build :user
+      #
       class ConsistentParenthesesStyle < ::RuboCop::Cop::Base
         extend AutoCorrector
         include ConfigurableEnforcedStyle
-        include RuboCop::FactoryBot::Language
-        include RuboCop::Cop::Util
-
-        def self.autocorrect_incompatible_with
-          [Style::MethodCallWithArgsParentheses]
-        end
+        include ConfigurableExplicitOnly
 
         MSG_REQUIRE_PARENS = 'Prefer method call with parentheses'
         MSG_OMIT_PARENS = 'Prefer method call without parentheses'
-
         FACTORY_CALLS = RuboCop::FactoryBot::Language::METHODS
-
         RESTRICT_ON_SEND = FACTORY_CALLS
 
         # @!method factory_call(node)
         def_node_matcher :factory_call, <<~PATTERN
           (send
-            {#factory_bot? nil?} %FACTORY_CALLS
+            #factory_call? %FACTORY_CALLS
             {sym str send lvar} _*
           )
         PATTERN
 
+        def self.autocorrect_incompatible_with
+          [Style::MethodCallWithArgsParentheses]
+        end
+
         def on_send(node)
           return if ambiguous_without_parentheses?(node)
 
-          factory_call(node) do
-            return if node.method?(:generate) && node.arguments.count > 1
-
-            if node.parenthesized?
-              process_with_parentheses(node)
-            else
-              process_without_parentheses(node)
-            end
-          end
+          factory_call(node) { register_offense(node) }
         end
 
         private
 
-        def process_with_parentheses(node)
-          return unless style == :omit_parentheses
+        def register_offense(node)
+          return if node.method?(:generate) && node.arguments.count > 1
+
+          register_offense_with_parentheses(node)
+          register_offense_without_parentheses(node)
+        end
+
+        def register_offense_with_parentheses(node)
+          return if style == :require_parentheses || !node.parenthesized?
           return unless same_line?(node, node.first_argument)
 
           add_offense(node.loc.selector,
@@ -86,8 +104,8 @@ module RuboCop
           end
         end
 
-        def process_without_parentheses(node)
-          return unless style == :require_parentheses
+        def register_offense_without_parentheses(node)
+          return if style == :omit_parentheses || node.parenthesized?
 
           add_offense(node.loc.selector,
                       message: MSG_REQUIRE_PARENS) do |corrector|

--- a/lib/rubocop/cop/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/factory_bot/create_list.rb
@@ -97,12 +97,12 @@ module RuboCop
 
         # @!method arguments_include_method_call?(node)
         def_node_matcher :arguments_include_method_call?, <<~PATTERN
-          (send #factory_call? :create (sym $_) `$(send ...))
+          (send #factory_call? :create sym `$(send ...))
         PATTERN
 
         # @!method factory_call(node)
         def_node_matcher :factory_call, <<~PATTERN
-          (send #factory_call? :create (sym $_) $...)
+          (send #factory_call? :create sym ...)
         PATTERN
 
         # @!method factory_list_call(node)

--- a/lib/rubocop/cop/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/factory_bot/create_list.rb
@@ -36,10 +36,31 @@ module RuboCop
       #   # good
       #   3.times.map { create :user }
       #
+      # @example `ExplicitOnly: false` (default)
+      #
+      #   # bad - with `EnforcedStyle: create_list`
+      #   3.times { FactoryBot.create :user }
+      #   3.times { create :user }
+      #
+      #   # good - with `EnforcedStyle: create_list`
+      #   FactoryBot.create_list :user, 3
+      #   create_list :user, 3
+      #
+      # @example `ExplicitOnly: true`
+      #
+      #   # bad - with `EnforcedStyle: create_list`
+      #   3.times { FactoryBot.create :user }
+      #
+      #   # good - with `EnforcedStyle: create_list`
+      #   FactoryBot.create_list :user, 3
+      #   create_list :user, 3
+      #   3.times { create :user }
+      #
       class CreateList < ::RuboCop::Cop::Base
         extend AutoCorrector
         include ConfigurableEnforcedStyle
         include RuboCop::FactoryBot::Language
+        include ConfigurableExplicitOnly
 
         MSG_CREATE_LIST = 'Prefer create_list.'
         MSG_N_TIMES = 'Prefer %<number>s.times.map.'
@@ -76,17 +97,17 @@ module RuboCop
 
         # @!method arguments_include_method_call?(node)
         def_node_matcher :arguments_include_method_call?, <<~PATTERN
-          (send ${nil? #factory_bot?} :create (sym $_) `$(send ...))
+          (send #factory_call? :create (sym $_) `$(send ...))
         PATTERN
 
         # @!method factory_call(node)
         def_node_matcher :factory_call, <<~PATTERN
-          (send ${nil? #factory_bot?} :create (sym $_) $...)
+          (send #factory_call? :create (sym $_) $...)
         PATTERN
 
         # @!method factory_list_call(node)
         def_node_matcher :factory_list_call, <<~PATTERN
-          (send {nil? #factory_bot?} :create_list (sym _) (int $_) ...)
+          (send #factory_call? :create_list (sym _) (int $_) ...)
         PATTERN
 
         def on_block(node) # rubocop:todo InternalAffairs/NumblockHandler

--- a/lib/rubocop/cop/factory_bot/factory_name_style.rb
+++ b/lib/rubocop/cop/factory_bot/factory_name_style.rb
@@ -23,10 +23,33 @@ module RuboCop
       #   create('user')
       #   build "user", username: "NAME"
       #
+      # @example `ExplicitOnly: false` (default)
+      #
+      #   # bad - with `EnforcedStyle: symbol`
+      #   FactoryBot.create('user')
+      #   create('user')
+      #
+      #   # good - with `EnforcedStyle: symbol`
+      #   FactoryBot.create(:user)
+      #   create(:user)
+      #
+      # @example `ExplicitOnly: true`
+      #
+      #   # bad - with `EnforcedStyle: symbol`
+      #   FactoryBot.create(:user)
+      #   FactoryBot.build "user", username: "NAME"
+      #
+      #   # good - with `EnforcedStyle: symbol`
+      #   FactoryBot.create('user')
+      #   FactoryBot.build "user", username: "NAME"
+      #   FactoryBot.create(:user)
+      #   create(:user)
+      #
       class FactoryNameStyle < ::RuboCop::Cop::Base
         extend AutoCorrector
         include ConfigurableEnforcedStyle
         include RuboCop::FactoryBot::Language
+        include ConfigurableExplicitOnly
 
         MSG = 'Use %<prefer>s to refer to a factory.'
         FACTORY_CALLS = RuboCop::FactoryBot::Language::METHODS
@@ -35,7 +58,7 @@ module RuboCop
         # @!method factory_call(node)
         def_node_matcher :factory_call, <<~PATTERN
           (send
-            {#factory_bot? nil?} %FACTORY_CALLS
+            #factory_call? %FACTORY_CALLS
             ${str sym} ...
           )
         PATTERN

--- a/lib/rubocop/cop/factory_bot/mixin/configurable_explicit_only.rb
+++ b/lib/rubocop/cop/factory_bot/mixin/configurable_explicit_only.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module FactoryBot
+      # Handles `ExplicitOnly` configuration parameters.
+      module ConfigurableExplicitOnly
+        include RuboCop::FactoryBot::Language
+
+        def factory_call?(node)
+          return factory_bot?(node) if explicit_only?
+
+          factory_bot?(node) || node.nil?
+        end
+
+        def explicit_only?
+          cop_config['ExplicitOnly']
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb
+++ b/spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb
@@ -2,8 +2,9 @@
 
 RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
   let(:cop_config) do
-    { 'EnforcedStyle' => enforced_style }
+    { 'EnforcedStyle' => enforced_style, 'ExplicitOnly' => explicit_only }
   end
+  let(:explicit_only) { false }
 
   context 'when EnforcedStyle is :enforce_parentheses' do
     let(:enforced_style) { :require_parentheses }
@@ -398,6 +399,56 @@ RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
       expect_no_offenses(<<~RUBY)
         generate()
         generate(:foo, :bar)
+      RUBY
+    end
+  end
+
+  context 'when ExplicitOnly is false' do
+    let(:enforced_style) { :require_parentheses }
+    let(:explicit_only) { false }
+
+    it 'register an offense when using `create` with an explicit receiver' do
+      expect_offense(<<~RUBY)
+        FactoryBot.create :user
+                   ^^^^^^ Prefer method call with parentheses
+      RUBY
+
+      expect_correction(<<~RUBY)
+        FactoryBot.create(:user)
+      RUBY
+    end
+
+    it 'register an offense when using `create` with no explicit receiver' do
+      expect_offense(<<~RUBY)
+        create :user
+        ^^^^^^ Prefer method call with parentheses
+      RUBY
+
+      expect_correction(<<~RUBY)
+        create(:user)
+      RUBY
+    end
+  end
+
+  context 'when ExplicitOnly is true' do
+    let(:enforced_style) { :require_parentheses }
+    let(:explicit_only) { true }
+
+    it 'register an offense when using `create` with an explicit receiver' do
+      expect_offense(<<~RUBY)
+        FactoryBot.create :user
+                   ^^^^^^ Prefer method call with parentheses
+      RUBY
+
+      expect_correction(<<~RUBY)
+        FactoryBot.create(:user)
+      RUBY
+    end
+
+    it 'dose not register an offense when using `create` ' \
+       'with no explicit receiver' do
+      expect_no_offenses(<<~RUBY)
+        create :user
       RUBY
     end
   end

--- a/spec/rubocop/cop/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/factory_bot/create_list_spec.rb
@@ -2,8 +2,9 @@
 
 RSpec.describe RuboCop::Cop::FactoryBot::CreateList do
   let(:cop_config) do
-    { 'EnforcedStyle' => enforced_style }
+    { 'EnforcedStyle' => enforced_style, 'ExplicitOnly' => explicit_only }
   end
+  let(:explicit_only) { false }
 
   context 'when EnforcedStyle is :create_list' do
     let(:enforced_style) { :create_list }
@@ -200,6 +201,57 @@ RSpec.describe RuboCop::Cop::FactoryBot::CreateList do
         create_list(:user, 3) { |user| create(:account, user: user) }
       RUBY
     end
+
+    context 'when ExplicitOnly is false' do
+      let(:explicit_only) { false }
+
+      it 'register an offense when using n.times with no arguments ' \
+         'and an explicit receiver' do
+        expect_offense(<<~RUBY)
+          3.times { FactoryBot.create :user }
+          ^^^^^^^ Prefer create_list.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          FactoryBot.create_list :user, 3
+        RUBY
+      end
+
+      it 'register an offense when using n.times with no arguments ' \
+         'and no explicit receiver' do
+        expect_offense(<<~RUBY)
+          3.times { create :user }
+          ^^^^^^^ Prefer create_list.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          create_list :user, 3
+        RUBY
+      end
+    end
+
+    context 'when ExplicitOnly is true' do
+      let(:explicit_only) { true }
+
+      it 'register an offense when using n.times with no arguments ' \
+         'and an explicit receiver' do
+        expect_offense(<<~RUBY)
+          3.times { FactoryBot.create :user }
+          ^^^^^^^ Prefer create_list.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          FactoryBot.create_list :user, 3
+        RUBY
+      end
+
+      it 'dose not register an offense when using n.times with no arguments ' \
+         'and no explicit receiver' do
+        expect_no_offenses(<<~RUBY)
+          3.times { create :user }
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is :n_times' do
@@ -264,6 +316,57 @@ RSpec.describe RuboCop::Cop::FactoryBot::CreateList do
       expect_no_offenses(<<~RUBY)
         SomeFactory.create_list :user, 3
       RUBY
+    end
+
+    context 'when ExplicitOnly is false' do
+      let(:explicit_only) { false }
+
+      it 'register an offense when using create_list ' \
+         'with no arguments and an explicit receiver' do
+        expect_offense(<<~RUBY)
+          FactoryBot.create_list :user, 3
+                     ^^^^^^^^^^^ Prefer 3.times.map.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          3.times.map { FactoryBot.create :user }
+        RUBY
+      end
+
+      it 'register an offense when using create_list ' \
+         'with no arguments and no explicit receiver' do
+        expect_offense(<<~RUBY)
+          create_list :user, 3
+          ^^^^^^^^^^^ Prefer 3.times.map.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          3.times.map { create :user }
+        RUBY
+      end
+    end
+
+    context 'when ExplicitOnly is true' do
+      let(:explicit_only) { true }
+
+      it 'register an offense when using create_list ' \
+         'with no arguments and an explicit receiver' do
+        expect_offense(<<~RUBY)
+          FactoryBot.create_list :user, 3
+                     ^^^^^^^^^^^ Prefer 3.times.map.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          3.times.map { FactoryBot.create :user }
+        RUBY
+      end
+
+      it 'dose not register an offense when using create_list ' \
+         'with no arguments and no explicit receiver' do
+        expect_no_offenses(<<~RUBY)
+          create_list :user, 3
+        RUBY
+      end
     end
 
     context 'when Ruby 2.7', :ruby27 do

--- a/spec/rubocop/cop/factory_bot/factory_name_style_spec.rb
+++ b/spec/rubocop/cop/factory_bot/factory_name_style_spec.rb
@@ -2,8 +2,9 @@
 
 RSpec.describe RuboCop::Cop::FactoryBot::FactoryNameStyle do
   let(:cop_config) do
-    { 'EnforcedStyle' => enforced_style }
+    { 'EnforcedStyle' => enforced_style, 'ExplicitOnly' => explicit_only }
   end
+  let(:explicit_only) { false }
 
   context 'when EnforcedStyle is :symbol' do
     let(:enforced_style) { :symbol }
@@ -223,6 +224,59 @@ RSpec.describe RuboCop::Cop::FactoryBot::FactoryNameStyle do
        'with keyword argument' do
       expect_no_offenses(<<~RUBY)
         build user: :foo
+      RUBY
+    end
+  end
+
+  context 'when ExplicitOnly is false' do
+    let(:enforced_style) { :symbol }
+    let(:explicit_only) { false }
+
+    it 'register an offense when using `create` ' \
+       'with string name and an explicit receiver' do
+      expect_offense(<<~RUBY)
+        FactoryBot.create('user')
+                          ^^^^^^ Use symbol to refer to a factory.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        FactoryBot.create(:user)
+      RUBY
+    end
+
+    it 'register an offense when using `create` ' \
+       'with string name and no explicit receiver' do
+      expect_offense(<<~RUBY)
+        create('user')
+               ^^^^^^ Use symbol to refer to a factory.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        create(:user)
+      RUBY
+    end
+  end
+
+  context 'when ExplicitOnly is true' do
+    let(:enforced_style) { :symbol }
+    let(:explicit_only) { true }
+
+    it 'register an offense when using `create` ' \
+       'with string name and an explicit receiver' do
+      expect_offense(<<~RUBY)
+        FactoryBot.create('user')
+                          ^^^^^^ Use symbol to refer to a factory.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        FactoryBot.create(:user)
+      RUBY
+    end
+
+    it 'dose not register an offense when using `create` ' \
+       'with string name and no explicit receiver' do
+      expect_no_offenses(<<~RUBY)
+        create('user')
       RUBY
     end
   end


### PR DESCRIPTION
Follow up: https://github.com/rubocop/rubocop-rspec/pull/1482#issuecomment-1315496663
Resolve: https://github.com/rubocop/rubocop-factory_bot/issues/5

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
