### PR TITLE
Remove unnecessary checklist item from pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,6 @@ If you have created a new cop:
 
 - [ ] Added the new cop to `config/default.yml`.
 - [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
-- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
 - [ ] The cop documents examples of good and bad code.
 - [ ] The tests assert both that bad code is reported and that good code is not reported.
 - [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.


### PR DESCRIPTION
When I was writing a description to create #19, I realized that this field was unnecessary. It makes sense in rubocop-rspec, but it doesn't in this repo.