### PR TITLE
Remove unnecessary `:config` metadata from specs

### DIFF
--- a/spec/rubocop/cop/factory_bot/factory_name_style_spec.rb
+++ b/spec/rubocop/cop/factory_bot/factory_name_style_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::FactoryBot::FactoryNameStyle, :config do
+RSpec.describe RuboCop::Cop::FactoryBot::FactoryNameStyle do
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/factory_bot/syntax_methods_spec.rb
+++ b/spec/rubocop/cop/factory_bot/syntax_methods_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::FactoryBot::SyntaxMethods, :config do
+RSpec.describe RuboCop::Cop::FactoryBot::SyntaxMethods do
   described_class::RESTRICT_ON_SEND.each do |method|
     it 'does not register an offense when used outside an example group' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Just refactoring.

Test cases in the spec/rubocop/cop/ directory are automatically assigned the `:config` metadata, so there is no need to add this in individual test files.

https://github.com/rubocop/rubocop-factory_bot/blob/9801c7d91e14df508b61fab9c3d2da642a4ce564/spec/spec_helper.rb#L20-L28

When a new cop is added to this project in the future, a new test file will be created by referring to the existing test files (while copy-and-pasting some of them), so I thought it would be better to delete these redundant code. In fact, I noticed this when I tried to create a new test file with reference to the existing test files at #19.