### PR TITLE
Change `FactoryBot/CreateList` so that it checks same factory calls in an Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Change `FactoryBot/CreateList` so that it considers `times.map`. ([@r7kamura])
 - Add `FactoryBot/RedundantFactoryOption` cop. ([@r7kamura])
 - Add `ExplicitOnly` configuration option to `FactoryBot/ConsistentParenthesesStyle`, `FactoryBot/CreateList` and `FactoryBot/FactoryNameStyle`. ([@ydah])
+- Change `FactoryBot/CreateList` so that it checks same factory calls in an Array. ([@r7kamura])
 
 ## 2.22.0 (2023-05-04)
 

--- a/docs/modules/ROOT/pages/cops_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_factorybot.adoc
@@ -179,6 +179,7 @@ This cop's autocorrection is unsafe because replacing `n.times` to
 # bad
 3.times { create :user }
 3.times.map { create :user }
+[create(:user), create(:user), create(:user)]
 Array.new(3) { create :user }
 
 # good
@@ -200,6 +201,7 @@ create_list :user, 3
 ----
 # bad
 create_list :user, 3
+[create(:user), create(:user), create(:user)]
 
 # good
 3.times.map { create :user }

--- a/lib/rubocop/cop/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/factory_bot/create_list.rb
@@ -15,6 +15,7 @@ module RuboCop
       #   # bad
       #   3.times { create :user }
       #   3.times.map { create :user }
+      #   [create(:user), create(:user), create(:user)]
       #   Array.new(3) { create :user }
       #
       #   # good
@@ -32,6 +33,7 @@ module RuboCop
       # @example `EnforcedStyle: n_times`
       #   # bad
       #   create_list :user, 3
+      #   [create(:user), create(:user), create(:user)]
       #
       #   # good
       #   3.times.map { create :user }
@@ -110,6 +112,22 @@ module RuboCop
           (send #factory_call? :create_list (sym _) (int $_) ...)
         PATTERN
 
+        # @!method factory_calls_in_array?(node)
+        def_node_search :factory_calls_in_array?, <<-PATTERN
+          (array #factory_call+)
+        PATTERN
+
+        def on_array(node)
+          return unless same_factory_calls_in_array?(node)
+
+          add_offense(
+            node,
+            message: preferred_message_for_array(node)
+          ) do |corrector|
+            autocorrect_same_factory_calls_in_array(corrector, node)
+          end
+        end
+
         def on_block(node) # rubocop:todo InternalAffairs/NumblockHandler
           return unless style == :create_list
 
@@ -137,12 +155,40 @@ module RuboCop
 
         private
 
+        # For ease of modification, it is replaced with the `n_times` style,
+        # but if it is not appropriate for the configured style,
+        # it will be replaced in the subsequent autocorrection.
+        def autocorrect_same_factory_calls_in_array(corrector, node)
+          corrector.replace(
+            node,
+            format(
+              '%<count>s.times { %<factory_call>s }',
+              count: node.children.count,
+              factory_call: node.children.first.source
+            )
+          )
+        end
+
         def contains_only_factory?(node)
           if node.block_type?
             factory_call(node.send_node)
           else
             factory_call(node)
           end
+        end
+
+        def preferred_message_for_array(node)
+          if style == :create_list &&
+              !arguments_include_method_call?(node.children.first)
+            MSG_CREATE_LIST
+          else
+            format(MSG_N_TIMES, number: node.children.count)
+          end
+        end
+
+        def same_factory_calls_in_array?(node)
+          factory_calls_in_array?(node) &&
+            node.children.map(&:source).uniq.one?
         end
 
         # :nodoc

--- a/lib/rubocop/cop/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/factory_bot/create_list.rb
@@ -162,7 +162,7 @@ module RuboCop
           corrector.replace(
             node,
             format(
-              '%<count>s.times { %<factory_call>s }',
+              '%<count>s.times.map { %<factory_call>s }',
               count: node.children.count,
               factory_call: node.children.first.source
             )

--- a/spec/rubocop/cop/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/factory_bot/create_list_spec.rb
@@ -248,15 +248,14 @@ RSpec.describe RuboCop::Cop::FactoryBot::CreateList do
       it 'registers and corrects an offense' do
         expect_offense(<<~RUBY)
           [create(:user, point: rand), create(:user, point: rand)]
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 2.times.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 2.times.map.
         RUBY
 
         expect_correction(<<~RUBY)
-          2.times { create(:user, point: rand) }
+          2.times.map { create(:user, point: rand) }
         RUBY
       end
     end
-  end
 
     context 'when ExplicitOnly is false' do
       let(:explicit_only) { false }
@@ -437,11 +436,11 @@ RSpec.describe RuboCop::Cop::FactoryBot::CreateList do
       it 'registers and corrects an offense' do
         expect_offense(<<~RUBY)
           [create(:user), create(:user)]
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 2.times.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 2.times.map.
         RUBY
 
         expect_correction(<<~RUBY)
-          2.times { create(:user) }
+          2.times.map { create(:user) }
         RUBY
       end
     end
@@ -450,11 +449,11 @@ RSpec.describe RuboCop::Cop::FactoryBot::CreateList do
       it 'registers and corrects an offense' do
         expect_offense(<<~RUBY)
           [create(:user, point: rand), create(:user, point: rand)]
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 2.times.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 2.times.map.
         RUBY
 
         expect_correction(<<~RUBY)
-          2.times { create(:user, point: rand) }
+          2.times.map { create(:user, point: rand) }
         RUBY
       end
     end

--- a/spec/rubocop/cop/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/factory_bot/create_list_spec.rb
@@ -202,6 +202,62 @@ RSpec.describe RuboCop::Cop::FactoryBot::CreateList do
       RUBY
     end
 
+    context 'with empty array' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          []
+        RUBY
+      end
+    end
+
+    context 'with different `create` nodes in array' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          [create(:user), create(:user, age: 18)]
+        RUBY
+      end
+    end
+
+    context 'with one `create` node in array' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          [create(:user)]
+          ^^^^^^^^^^^^^^^ Prefer create_list.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          create_list(:user, 1)
+        RUBY
+      end
+    end
+
+    context 'with same `create` nodes in array' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          [create(:user), create(:user)]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer create_list.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          create_list(:user, 2)
+        RUBY
+      end
+    end
+
+    context 'with same `create` nodes in array with method calls' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          [create(:user, point: rand), create(:user, point: rand)]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 2.times.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          2.times { create(:user, point: rand) }
+        RUBY
+      end
+    end
+  end
+
     context 'when ExplicitOnly is false' do
       let(:explicit_only) { false }
 
@@ -373,6 +429,32 @@ RSpec.describe RuboCop::Cop::FactoryBot::CreateList do
       it 'ignores n.times with numblock' do
         expect_no_offenses(<<~RUBY)
           3.times { create :user, position: _1 }
+        RUBY
+      end
+    end
+
+    context 'with same `create` nodes in array' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          [create(:user), create(:user)]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 2.times.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          2.times { create(:user) }
+        RUBY
+      end
+    end
+
+    context 'with same `create` nodes in array with method calls' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          [create(:user, point: rand), create(:user, point: rand)]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 2.times.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          2.times { create(:user, point: rand) }
         RUBY
       end
     end


### PR DESCRIPTION
Recreated from the following pull request:

- https://github.com/rubocop/rubocop-rspec/pull/1467

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).