### PR TITLE
Replace heredoc `<<-` with `<<~` and adjust indentation

### DIFF
--- a/lib/rubocop/cop/factory_bot/attribute_defined_statically.rb
+++ b/lib/rubocop/cop/factory_bot/attribute_defined_statically.rb
@@ -30,13 +30,13 @@ module RuboCop
         MSG = 'Use a block to declare attribute values.'
 
         # @!method value_matcher(node)
-        def_node_matcher :value_matcher, <<-PATTERN
-            (send _ !#reserved_method? $...)
+        def_node_matcher :value_matcher, <<~PATTERN
+          (send _ !#reserved_method? $...)
         PATTERN
 
         # @!method factory_attributes(node)
-        def_node_matcher :factory_attributes, <<-PATTERN
-            (block (send _ #attribute_defining_method? ...) _ { (begin $...) $(send ...) } )
+        def_node_matcher :factory_attributes, <<~PATTERN
+          (block (send _ #attribute_defining_method? ...) _ { (begin $...) $(send ...) } )
         PATTERN
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler

--- a/lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb
+++ b/lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb
@@ -53,11 +53,11 @@ module RuboCop
         RESTRICT_ON_SEND = FACTORY_CALLS
 
         # @!method factory_call(node)
-        def_node_matcher :factory_call, <<-PATTERN
-            (send
-              {#factory_bot? nil?} %FACTORY_CALLS
-              {sym str send lvar} _*
-            )
+        def_node_matcher :factory_call, <<~PATTERN
+          (send
+            {#factory_bot? nil?} %FACTORY_CALLS
+            {sym str send lvar} _*
+          )
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/factory_bot/create_list.rb
@@ -40,38 +40,38 @@ module RuboCop
         RESTRICT_ON_SEND = %i[create_list].freeze
 
         # @!method array_new_or_n_times_block?(node)
-        def_node_matcher :array_new_or_n_times_block?, <<-PATTERN
-            (block
-              {
-                (send (const {nil? | cbase} :Array) :new (int _)) |
-                (send (int _) :times)
-              }
-              ...
-            )
+        def_node_matcher :array_new_or_n_times_block?, <<~PATTERN
+          (block
+            {
+              (send (const {nil? | cbase} :Array) :new (int _)) |
+              (send (int _) :times)
+            }
+            ...
+          )
         PATTERN
 
         # @!method block_with_arg_and_used?(node)
-        def_node_matcher :block_with_arg_and_used?, <<-PATTERN
-            (block
-              _
-              (args (arg _value))
-              `_value
-            )
+        def_node_matcher :block_with_arg_and_used?, <<~PATTERN
+          (block
+            _
+            (args (arg _value))
+            `_value
+          )
         PATTERN
 
         # @!method arguments_include_method_call?(node)
-        def_node_matcher :arguments_include_method_call?, <<-PATTERN
-            (send ${nil? #factory_bot?} :create (sym $_) `$(send ...))
+        def_node_matcher :arguments_include_method_call?, <<~PATTERN
+          (send ${nil? #factory_bot?} :create (sym $_) `$(send ...))
         PATTERN
 
         # @!method factory_call(node)
-        def_node_matcher :factory_call, <<-PATTERN
-            (send ${nil? #factory_bot?} :create (sym $_) $...)
+        def_node_matcher :factory_call, <<~PATTERN
+          (send ${nil? #factory_bot?} :create (sym $_) $...)
         PATTERN
 
         # @!method factory_list_call(node)
-        def_node_matcher :factory_list_call, <<-PATTERN
-            (send {nil? #factory_bot?} :create_list (sym _) (int $_) ...)
+        def_node_matcher :factory_list_call, <<~PATTERN
+          (send {nil? #factory_bot?} :create_list (sym _) (int $_) ...)
         PATTERN
 
         def on_block(node) # rubocop:todo InternalAffairs/NumblockHandler

--- a/lib/rubocop/cop/factory_bot/factory_name_style.rb
+++ b/lib/rubocop/cop/factory_bot/factory_name_style.rb
@@ -33,7 +33,7 @@ module RuboCop
         RESTRICT_ON_SEND = FACTORY_CALLS
 
         # @!method factory_call(node)
-        def_node_matcher :factory_call, <<-PATTERN
+        def_node_matcher :factory_call, <<~PATTERN
           (send
             {#factory_bot? nil?} %FACTORY_CALLS
             ${str sym} ...

--- a/rubocop-factory_bot.gemspec
+++ b/rubocop-factory_bot.gemspec
@@ -6,7 +6,7 @@ require 'rubocop/factory_bot/version'
 Gem::Specification.new do |spec|
   spec.name = 'rubocop-factory_bot'
   spec.summary = 'Code style checking for factory_bot files'
-  spec.description = <<-DESCRIPTION
+  spec.description = <<~DESCRIPTION
     Code style checking for factory_bot files.
     A plugin for the RuboCop code style enforcing & linting tool.
   DESCRIPTION

--- a/spec/rubocop/cop/factory_bot/attribute_defined_statically_spec.rb
+++ b/spec/rubocop/cop/factory_bot/attribute_defined_statically_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
   it 'registers an offense for offending code' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       FactoryBot.define do
         factory :post do
           title "Something"
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       FactoryBot.define do
         factory :post do
           title { "Something" }
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
   end
 
   it 'registers an offense in a trait' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       FactoryBot.define do
         factory :post do
           trait :published do
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       FactoryBot.define do
         factory :post do
           trait :published do
@@ -80,7 +80,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
   end
 
   it 'registers an offense in a transient block' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       FactoryBot.define do
         factory :post do
           transient do
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       FactoryBot.define do
         factory :post do
           transient do
@@ -106,7 +106,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
   end
 
   it 'registers an offense for an attribute defined on `self`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       FactoryBot.define do
         factory :post do
           self.start { Date.today }
@@ -116,7 +116,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       FactoryBot.define do
         factory :post do
           self.start { Date.today }
@@ -127,7 +127,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
   end
 
   it 'registers an offense for attributes defined on explicit receiver' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       FactoryBot.define do
         factory :post do |post_definition|
           post_definition.end Date.tomorrow
@@ -140,7 +140,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       FactoryBot.define do
         factory :post do |post_definition|
           post_definition.end { Date.tomorrow }
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
   end
 
   it 'accepts valid factory definitions' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       FactoryBot.define do
         factory :post do
           trait :published do
@@ -175,7 +175,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
   end
 
   it 'does not add offense if out of factory_bot block' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       status [:draft, :published].sample
       published_at 1.day.from_now
       created_at 1.day.ago
@@ -185,7 +185,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
   end
 
   it 'does not add offense if method called on another object' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       FactoryBot.define do
         factory :post do |post_definition|
           Registrar.register :post_factory
@@ -195,7 +195,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
   end
 
   it 'does not add offense if method called on a local variable' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       FactoryBot.define do
         factory :post do |post_definition|
           local = Registrar
@@ -206,7 +206,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
   end
 
   it 'accepts valid association definitions' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       FactoryBot.define do
         factory :post do
           author age: 42, factory: :user
@@ -216,7 +216,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
   end
 
   it 'accepts valid sequence definition' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       FactoryBot.define do
         factory :post do
           sequence :negative_numbers, &:-@
@@ -226,7 +226,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::AttributeDefinedStatically do
   end
 
   it 'accepts valid traits_for_enum definition' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       FactoryBot.define do
         factory :post do
           traits_for_enum :status, [:draft, :published]

--- a/spec/rubocop/factory_bot/config_formatter_spec.rb
+++ b/spec/rubocop/factory_bot/config_formatter_spec.rb
@@ -40,28 +40,28 @@ RSpec.describe RuboCop::FactoryBot::ConfigFormatter do
   it 'builds a YAML dump with spacing between cops' do
     formatter = described_class.new(config, descriptions)
 
-    expect(formatter.dump).to eql(<<-YAML.gsub(/^\s+\|/, ''))
-      |---
-      |AllCops:
-      |  Setting: forty two
-      |
-      |FactoryBot/Foo:
-      |  Config: 2
-      |  Enabled: true
-      |  Description: Blah
-      |  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/Foo
-      |
-      |FactoryBot/Bar:
-      |  Enabled: true
-      |  Nullable: ~
-      |  Description: Wow
-      |  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/Bar
-      |
-      |FactoryBot/Baz:
-      |  Enabled: true
-      |  StyleGuide: "#buzz"
-      |  Description: Woof
-      |  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/Baz
+    expect(formatter.dump).to eql(<<~YAML)
+      ---
+      AllCops:
+        Setting: forty two
+
+      FactoryBot/Foo:
+        Config: 2
+        Enabled: true
+        Description: Blah
+        Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/Foo
+
+      FactoryBot/Bar:
+        Enabled: true
+        Nullable: ~
+        Description: Wow
+        Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/Bar
+
+      FactoryBot/Baz:
+        Enabled: true
+        StyleGuide: "#buzz"
+        Description: Woof
+        Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/Baz
     YAML
   end
 end

--- a/spec/rubocop/factory_bot/description_extractor_spec.rb
+++ b/spec/rubocop/factory_bot/description_extractor_spec.rb
@@ -6,7 +6,7 @@ require 'rubocop/factory_bot/description_extractor'
 
 RSpec.describe RuboCop::FactoryBot::DescriptionExtractor do
   let(:yardocs) do
-    YARD.parse_string(<<-RUBY)
+    YARD.parse_string(<<~RUBY)
       # This is not a cop
       class RuboCop::Cop::Mixin::Sneaky
       end


### PR DESCRIPTION
Just refactoring.

I found that some heredoc indentations are wrong, so I replaced all `<<-` with `<<~`. This way, `Layout/HeredocIndentation` will point out and autocorrect the mis-indentations. And also, since it does not include unnecessary whitespace, there is no longer need to add workaround on spec/rubocop/factory_bot/config_formatter_spec.rb.

Maybe the original code existed for Ruby 2.2- compatibility (`<<~` was introduced from Ruby 2.3), so we couldn't use this back then, but now it requires Ruby 2.7 or higher, so we can do this.