### PR TITLE
Add cop flag explicit factory bot dsl method usage in association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Add `FactoryBot/FactoryAssociationWithStrategy` cop. ([@morissetcl])
 - Mark `FactoryBot/CreateList` as `SafeAutoCorrect: false`. ([@r7kamura])
 - Add `FactoryBot/RedundantFactoryOption` cop. ([@r7kamura])
 
@@ -60,6 +61,7 @@
 [@jonatas]: https://github.com/jonatas
 [@leoarnold]: https://github.com/leoarnold
 [@liberatys]: https://github.com/Liberatys
+[@morissetcl]: https://github.com/morissetcl
 [@ngouy]: https://github.com/ngouy
 [@pirj]: https://github.com/pirj
 [@r7kamura]: https://github.com/r7kamura

--- a/config/default.yml
+++ b/config/default.yml
@@ -47,6 +47,13 @@ FactoryBot/CreateList:
   VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/CreateList
 
+FactoryBot/FactoryAssociationWithStrategy:
+  Description: Use definition in factory association instead of hard coding a strategy.
+  Enabled: pending
+  VersionAdded: "<<next>>"
+  VersionChanged: '2.23'
+  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/FactoryAssociationWithStrategy
+
 FactoryBot/FactoryClassName:
   Description: Use string value when setting the class attribute explicitly.
   Enabled: true

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -5,6 +5,7 @@
 * xref:cops_factorybot.adoc#factorybotattributedefinedstatically[FactoryBot/AttributeDefinedStatically]
 * xref:cops_factorybot.adoc#factorybotconsistentparenthesesstyle[FactoryBot/ConsistentParenthesesStyle]
 * xref:cops_factorybot.adoc#factorybotcreatelist[FactoryBot/CreateList]
+* xref:cops_factorybot.adoc#factorybotfactoryassociationwithstrategy[FactoryBot/FactoryAssociationWithStrategy]
 * xref:cops_factorybot.adoc#factorybotfactoryclassname[FactoryBot/FactoryClassName]
 * xref:cops_factorybot.adoc#factorybotfactorynamestyle[FactoryBot/FactoryNameStyle]
 * xref:cops_factorybot.adoc#factorybotredundantfactoryoption[FactoryBot/RedundantFactoryOption]

--- a/docs/modules/ROOT/pages/cops_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_factorybot.adoc
@@ -189,6 +189,49 @@ create_list :user, 3
 
 * https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/CreateList
 
+== FactoryBot/FactoryAssociationWithStrategy
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Pending
+| Yes
+| No
+| <<next>>
+| 2.23
+|===
+
+Use definition in factory association instead of hard coding a strategy.
+
+=== Examples
+
+[source,ruby]
+----
+# bad - only works for one strategy
+factory :foo do
+  profile { create(:profile) }
+end
+
+# good - implicit
+factory :foo do
+  profile
+end
+
+# good - explicit
+factory :foo do
+  association :profile
+end
+
+# good - inline
+factory :foo do
+  profile { association :profile }
+end
+----
+
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/FactoryAssociationWithStrategy
+
 == FactoryBot/FactoryClassName
 
 |===

--- a/lib/rubocop/cop/factory_bot/factory_association_with_strategy.rb
+++ b/lib/rubocop/cop/factory_bot/factory_association_with_strategy.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module FactoryBot
+      # Use definition in factory association instead of hard coding a strategy.
+      #
+      # @example
+      #   # bad - only works for one strategy
+      #   factory :foo do
+      #     profile { create(:profile) }
+      #   end
+      #
+      #   # good - implicit
+      #   factory :foo do
+      #     profile
+      #   end
+      #
+      #   # good - explicit
+      #   factory :foo do
+      #     association :profile
+      #   end
+      #
+      #   # good - inline
+      #   factory :foo do
+      #     profile { association :profile }
+      #   end
+      #
+      class FactoryAssociationWithStrategy < ::RuboCop::Cop::Base
+        MSG = 'Use an implicit, explicit or inline definition instead of ' \
+              'hard coding a strategy for setting association within factory.'
+
+        HARDCODED = Set.new(%i[create build build_stubbed]).freeze
+
+        # @!method factory_declaration(node)
+        def_node_matcher :factory_declaration, <<~PATTERN
+          (block (send nil? {:factory :trait} ...)
+            ...
+          )
+        PATTERN
+
+        # @!method factory_strategy_association(node)
+        def_node_matcher :factory_strategy_association, <<~PATTERN
+          (block
+            (send nil? _association_name)
+            (args)
+            < $(send nil? HARDCODED ...) ... >
+          )
+        PATTERN
+
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+          factory_declaration(node) do
+            node.each_node do |statement|
+              factory_strategy_association(statement) do |hardcoded_association|
+                add_offense(hardcoded_association)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/factory_bot_cops.rb
+++ b/lib/rubocop/cop/factory_bot_cops.rb
@@ -3,6 +3,7 @@
 require_relative 'factory_bot/attribute_defined_statically'
 require_relative 'factory_bot/consistent_parentheses_style'
 require_relative 'factory_bot/create_list'
+require_relative 'factory_bot/factory_association_with_strategy'
 require_relative 'factory_bot/factory_class_name'
 require_relative 'factory_bot/factory_name_style'
 require_relative 'factory_bot/redundant_factory_option'

--- a/spec/rubocop/cop/factory_bot/factory_association_with_strategy_spec.rb
+++ b/spec/rubocop/cop/factory_bot/factory_association_with_strategy_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::FactoryBot::FactoryAssociationWithStrategy do
+  context 'when passing an hardcoded strategy' do
+    context 'when passing a `create` strategy' do
+      it 'flags the strategy' do
+        expect_offense(<<~RUBY)
+          factory :foo, class: 'FOOO' do
+            profile { create(:profile) }
+                      ^^^^^^^^^^^^^^^^ Use an implicit, explicit or inline definition instead of hard coding a strategy for setting association within factory.
+          end
+        RUBY
+      end
+    end
+
+    context 'when passing a `build` strategy' do
+      it 'flags the strategy' do
+        expect_offense(<<~RUBY)
+          factory :foo do
+            profile { build(:profile) }
+                      ^^^^^^^^^^^^^^^ Use an implicit, explicit or inline definition instead of hard coding a strategy for setting association within factory.
+          end
+        RUBY
+      end
+    end
+
+    context 'when passing a `build_stubbed` strategy' do
+      it 'flags the strategy' do
+        expect_offense(<<~RUBY)
+          factory :foo do
+            profile { build_stubbed(:profile) }
+                      ^^^^^^^^^^^^^^^^^^^^^^^ Use an implicit, explicit or inline definition instead of hard coding a strategy for setting association within factory.
+          end
+        RUBY
+      end
+    end
+
+    context 'when passing an additional argument' do
+      it 'flags the strategy' do
+        expect_offense(<<~RUBY)
+          factory :foo do
+            profile { build_stubbed(:profile, :qualified) }
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use an implicit, explicit or inline definition instead of hard coding a strategy for setting association within factory.
+          end
+        RUBY
+      end
+    end
+
+    context 'when having multiple hardcoded strategies' do
+      it 'flags all the strategies' do
+        expect_offense(<<~RUBY)
+          factory :foo do
+            profile { build_stubbed(:profile) }
+                      ^^^^^^^^^^^^^^^^^^^^^^^ Use an implicit, explicit or inline definition instead of hard coding a strategy for setting association within factory.
+
+            area { create(:area) }
+                   ^^^^^^^^^^^^^ Use an implicit, explicit or inline definition instead of hard coding a strategy for setting association within factory.
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'when passing a block who does not use strategy' do
+    context 'when passing an inline association' do
+      it 'does not flag' do
+        expect_no_offenses(<<~RUBY)
+          factory :foo do
+            profile { association :profile }
+          end
+        RUBY
+      end
+    end
+
+    context 'when passing an implicit association' do
+      it 'does not flag' do
+        expect_no_offenses(<<~RUBY)
+          factory :foo do
+            profile
+          end
+        RUBY
+      end
+    end
+
+    context 'when passing an explicit association' do
+      it 'does not flag' do
+        expect_no_offenses(<<~RUBY)
+          factory :foo do
+            association :profile
+          end
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #6

This cop will add an offense when a strategy is hardcoded to create an association in a factory.

      # bad - only works for one strategy
        factory :foo do
          profile { create(:profile) }
        end

      # good - implicit
        factory :foo do
          profile
        end
      
      # good - explicit
        factory :foo do
          association :profile
        end
        
      # good - inline
        factory :foo do
          profile { association :profile }
        end


______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] Added the new cop to `config/default.yml`.
- [x] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [x] The cop documents examples of good and bad code.
- [x] The tests assert both that bad code is reported and that good code is not reported.
- [x] Set `VersionAdded: "<<next>>"` in `default/config.yml`.
