### PR TITLE
Change `FactoryBot/CreateList` so that it is not an offense if not repeated multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix `FactoryBot/AssociationStyle` cop to ignore explicit associations with `strategy: :build`. ([@pirj])
+- Change `FactoryBot/CreateList` so that it is not an offense if not repeated multiple times. ([@ydah])
 
 ## 2.23.1 (2023-05-15)
 

--- a/spec/rubocop/cop/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/factory_bot/create_list_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe RuboCop::Cop::FactoryBot::CreateList do
       RUBY
     end
 
+    it 'ignores usage of 1.times' do
+      expect_no_offenses(<<~RUBY)
+        1.times { create :user }
+      RUBY
+    end
+
     it 'flags usage of n.times when FactoryGirl.create is used' do
       expect_offense(<<~RUBY)
         3.times { FactoryGirl.create :user }
@@ -71,9 +77,17 @@ RSpec.describe RuboCop::Cop::FactoryBot::CreateList do
       RUBY
     end
 
-    it 'ignores n.times when create call does have method calls' do
+    it 'ignores n.times when create call does have method calls ' \
+       'and repeat multiple times' do
       expect_no_offenses(<<~RUBY)
         3.times { |n| create :user, repositories_count: rand }
+      RUBY
+    end
+
+    it 'ignores n.times when create call does have method calls ' \
+       'and not repeat' do
+      expect_no_offenses(<<~RUBY)
+        1.times { |n| create :user, repositories_count: rand }
       RUBY
     end
 
@@ -178,6 +192,12 @@ RSpec.describe RuboCop::Cop::FactoryBot::CreateList do
       RUBY
     end
 
+    it 'ignores n.times.map when create call does have method calls' do
+      expect_no_offenses(<<~RUBY)
+        3.times.map { create :user, repositories_count: rand }
+      RUBY
+    end
+
     it 'flags usage of Array.new(n) with no arguments' do
       expect_offense(<<~RUBY)
         Array.new(3) { create(:user) }
@@ -219,14 +239,9 @@ RSpec.describe RuboCop::Cop::FactoryBot::CreateList do
     end
 
     context 'with one `create` node in array' do
-      it 'registers and corrects an offense' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
           [create(:user)]
-          ^^^^^^^^^^^^^^^ Prefer create_list.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          create_list(:user, 1)
         RUBY
       end
     end
@@ -320,6 +335,12 @@ RSpec.describe RuboCop::Cop::FactoryBot::CreateList do
 
       expect_correction(<<~RUBY)
         3.times.map { create :user }
+      RUBY
+    end
+
+    it 'ignores create_list :user, 1' do
+      expect_no_offenses(<<~RUBY)
+        create_list :user, 1
       RUBY
     end
 


### PR DESCRIPTION
~This PR is add support cases of offense for `FactoryBot/CreateList` when create call dees have method call in the argument, but it does not repeat multiple times.~

~In the case of multiple repeats, the following problems were ignored.~
~- https://github.com/rubocop/rubocop-rspec/issues/1087~

~However, if it is not repeated more than once, it is not a problem as an offense.~

This PR is change `FactoryBot/CreateList` so that it is not an offense if not repeated multiple times.

Fix: https://github.com/rubocop/rubocop-factory_bot/issues/49

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).