### PR TITLE
Fix a false positive for `FactoryBot/AssociationStyle` when `association` is called in trait block and column name is keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix `FactoryBot/AssociationStyle` cop to ignore explicit associations with `strategy: :build`. ([@pirj])
 - Change `FactoryBot/CreateList` so that it is not an offense if not repeated multiple times. ([@ydah])
+- Fix a false positive for `FactoryBot/AssociationStyle` when `association` is called in trait block and column name is keyword. ([@ydah])
 
 ## 2.23.1 (2023-05-15)
 

--- a/spec/rubocop/cop/factory_bot/association_style_spec.rb
+++ b/spec/rubocop/cop/factory_bot/association_style_spec.rb
@@ -177,6 +177,49 @@ RSpec.describe RuboCop::Cop::FactoryBot::AssociationStyle do
         RUBY
       end
     end
+
+    context 'when `association` is called in trait block ' \
+            'and column name is keyword' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          factory :article do
+            trait :with_class do
+              association :alias
+              association :and, factory: :user
+              association :foo, :__FILE__
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when `association` is called in trait block ' \
+            'and factory option is keyword' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          factory :article do
+            trait :with_class do
+              association :foo, factory: :alias
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use implicit style to define associations.
+              association :bar, factory: :and
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use implicit style to define associations.
+              association :baz, factory: :__FILE__
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use implicit style to define associations.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          factory :article do
+            trait :with_class do
+              foo factory: %i[alias]
+              bar factory: %i[and]
+              baz factory: %i[__FILE__]
+            end
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is :explicit' do


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-factory_bot/issues/58

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).