### PR TITLE
Add a Danger check to prevent review approval for cops that have become `Enabled: true`

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,22 @@
+name: Danger
+on:
+  - pull_request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+jobs:
+  danger:
+    name: Danger
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: "3.2"
+      - name: Run Danger
+        run: bundle exec danger
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+diff = git.diff_for_file('config/default.yml')
+if diff && diff.patch =~ /^\+\s*Enabled: true$/
+  warn(<<~MESSAGE)
+    There is a cop that became `Enabled: true` due to this pull request.
+    Please review the diff and make sure there are no issues.
+  MESSAGE
+end

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'bump'
+gem 'danger'
 gem 'rack'
 gem 'rake'
 gem 'rspec', '~> 3.11'


### PR DESCRIPTION
Follow up: https://github.com/rubocop/rubocop-rspec/pull/1617

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
