### PR TITLE
Bump version to v2.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.24.0 (2023-09-18)
+
 - Fix `FactoryBot/AssociationStyle` cop to ignore explicit associations with `strategy: :build`. ([@pirj])
 - Change `FactoryBot/CreateList` so that it is not an offense if not repeated multiple times. ([@ydah])
 - Fix a false positive for `FactoryBot/AssociationStyle` when `association` is called in trait block and column name is keyword. ([@ydah])

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-factory_bot
 title: RuboCop factory_bot
-version: ~
+version: '2.24'
 nav:
   - modules/ROOT/nav.adoc

--- a/lib/rubocop/factory_bot/version.rb
+++ b/lib/rubocop/factory_bot/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module FactoryBot
     # Version information for the factory_bot RuboCop plugin.
     module Version
-      STRING = '2.23.1'
+      STRING = '2.24.0'
     end
   end
 end


### PR DESCRIPTION
It has been more than 3 months since the last time and it is time to release the next version.

It would be good to include the next PR in the next release:
- [x] https://github.com/rubocop/rubocop-factory_bot/pull/55
- [x] https://github.com/rubocop/rubocop-factory_bot/pull/52

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).