### PR TITLE
Fix rubocop offense

### DIFF
--- a/lib/rubocop/cop/factory_bot/association_style.rb
+++ b/lib/rubocop/cop/factory_bot/association_style.rb
@@ -248,7 +248,7 @@ module RuboCop
 
         def trait_within_trait?(node)
           factory_node = node.ancestors.reverse.find do |ancestor|
-            ancestor.send_node.method?(:factory) if ancestor.block_type?
+            ancestor.method?(:factory) if ancestor.block_type?
           end
 
           trait_name(factory_node).include?(node.method_name)


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-factory_bot/actions/runs/6063658775/job/16451253608?pr=67

```ruby
lib/rubocop/cop/factory_bot/association_style.rb:251:21: C: [Corrected] InternalAffairs/RedundantMethodDispatchNode: Remove the redundant send_node.
            ancestor.send_node.method?(:factory) if ancestor.block_type?
                    ^^^^^^^^^^
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).