### PR TITLE
Fix a false positive for `FactoryBot/FactoryNameStyle` when namespaced models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix a false positive for `FactoryBot/FactoryNameStyle` when namespaced models. ([@ydah])
+
 ## 2.24.0 (2023-09-18)
 
 - Fix `FactoryBot/AssociationStyle` cop to ignore explicit associations with `strategy: :build`. ([@pirj])

--- a/docs/modules/ROOT/pages/cops_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_factorybot.adoc
@@ -464,6 +464,9 @@ build "user", username: "NAME"
 # good
 create(:user)
 build :user, username: "NAME"
+
+# good - namespaced models
+create('users/internal')
 ----
 
 ==== EnforcedStyle: string

--- a/lib/rubocop/cop/factory_bot/factory_name_style.rb
+++ b/lib/rubocop/cop/factory_bot/factory_name_style.rb
@@ -14,6 +14,9 @@ module RuboCop
       #   create(:user)
       #   build :user, username: "NAME"
       #
+      #   # good - namespaced models
+      #   create('users/internal')
+      #
       # @example EnforcedStyle: string
       #   # bad
       #   create(:user)
@@ -76,11 +79,15 @@ module RuboCop
         private
 
         def offense_for_symbol_style?(name)
-          name.str_type? && style == :symbol
+          name.str_type? && style == :symbol && !namespaced?(name)
         end
 
         def offense_for_string_style?(name)
           name.sym_type? && style == :string
+        end
+
+        def namespaced?(name)
+          name.value.include?('/')
         end
 
         def register_offense(name, prefer)

--- a/spec/rubocop/cop/factory_bot/factory_name_style_spec.rb
+++ b/spec/rubocop/cop/factory_bot/factory_name_style_spec.rb
@@ -97,6 +97,13 @@ RSpec.describe RuboCop::Cop::FactoryBot::FactoryNameStyle do
         build user: :foo
       RUBY
     end
+
+    it 'does not register an offense when using `create` ' \
+       'with a method call when string include /' do
+      expect_no_offenses(<<~RUBY)
+        create("users/internal")
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is :string' do


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-factory_bot/issues/62

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).