### PR TITLE
Fix a false positive for `FactoryBot/ConsistentParenthesesStyle` when hash pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix a false positive for `FactoryBot/FactoryNameStyle` when namespaced models. ([@ydah])
 - Add new `FactoryBot/ExcessiveCreateList` cop. ([@ddieulivol])
+- Fix a false positive for `FactoryBot/ConsistentParenthesesStyle` when hash pinning. ([@ydah])
 
 ## 2.24.0 (2023-09-18)
 

--- a/lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb
+++ b/lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb
@@ -75,6 +75,17 @@ module RuboCop
           )
         PATTERN
 
+        # @!method omit_hash_value?(node)
+        def_node_matcher :omit_hash_value?, <<~PATTERN
+          (send
+            #factory_call? %FACTORY_CALLS
+            {sym str send lvar}
+            (hash
+              <value_omission? ...>
+            )
+          )
+        PATTERN
+
         def self.autocorrect_incompatible_with
           [Style::MethodCallWithArgsParentheses]
         end
@@ -97,6 +108,7 @@ module RuboCop
         def register_offense_with_parentheses(node)
           return if style == :require_parentheses || !node.parenthesized?
           return unless same_line?(node, node.first_argument)
+          return if omit_hash_value?(node)
 
           add_offense(node.loc.selector,
                       message: MSG_OMIT_PARENS) do |corrector|

--- a/spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb
+++ b/spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb
@@ -405,6 +405,48 @@ RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
         generate(:foo, :bar)
       RUBY
     end
+
+    context 'when TargetRubyVersion >= 3.1', :ruby31 do
+      it 'does not register an offense when using `create` ' \
+         'with pinned hash argument' do
+        expect_no_offenses(<<~RUBY)
+          create(:user, name:)
+          create(:user, name:, client:)
+        RUBY
+      end
+
+      it 'does not register an offense when using `create` ' \
+         'with pinned hash argument and other unpinned args' do
+        expect_no_offenses(<<~RUBY)
+          create(:user, client:, name: 'foo')
+          create(:user, client: 'foo', name:)
+        RUBY
+      end
+
+      it 'registers an offense when using `create` ' \
+         'with unpinned hash argument' do
+        expect_offense(<<~RUBY)
+          create(:user, name: 'foo')
+          ^^^^^^ Prefer method call without parentheses
+        RUBY
+
+        expect_correction(<<~RUBY)
+          create :user, name: 'foo'
+        RUBY
+      end
+
+      it 'registers an offense when using `create` ' \
+         'with method call has pinned hash argument' do
+        expect_offense(<<~RUBY)
+          create(:user, foo(name:))
+          ^^^^^^ Prefer method call without parentheses
+        RUBY
+
+        expect_correction(<<~RUBY)
+          create :user, foo(name:)
+        RUBY
+      end
+    end
   end
 
   context 'when ExplicitOnly is false' do


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-factory_bot/issues/84

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
