### PR TITLE
Use `spec.add_runtime_dependency 'rubocop', '~> 1.41'`

### DIFF
--- a/rubocop-factory_bot.gemspec
+++ b/rubocop-factory_bot.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.33'
+  spec.add_runtime_dependency 'rubocop', '~> 1.41'
 end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-factory_bot/issues/89

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
