### PR TITLE
Fix an error occurred for `FactoryBot/IdSequence` when `sequence` with non-symbol argument or without argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix a false positive for `FactoryBot/CreateList` when create call does have method calls and repeat multiple times with other argument. ([@ydah])
+- Fix an error occurred for `FactoryBot/IdSequence` when `sequence` with non-symbol argument or without argument. ([@ydah])
 
 ## 2.25.0 (2024-01-04)
 

--- a/lib/rubocop/cop/factory_bot/id_sequence.rb
+++ b/lib/rubocop/cop/factory_bot/id_sequence.rb
@@ -19,12 +19,15 @@ module RuboCop
       class IdSequence < ::RuboCop::Cop::Base
         extend AutoCorrector
         include RangeHelp
+        include RuboCop::FactoryBot::Language
 
         MSG = 'Do not create a sequence for an id attribute'
         RESTRICT_ON_SEND = %i[sequence].freeze
 
         def on_send(node)
-          return unless node.first_argument.value == :id
+          return unless node.receiver.nil? || factory_bot?(node.receiver)
+          return unless node.first_argument&.sym_type? &&
+            node.first_argument.value == :id
 
           add_offense(node) do |corrector|
             range_to_remove = range_by_whole_lines(

--- a/spec/rubocop/cop/factory_bot/id_sequence_spec.rb
+++ b/spec/rubocop/cop/factory_bot/id_sequence_spec.rb
@@ -103,4 +103,28 @@ RSpec.describe RuboCop::Cop::FactoryBot::IdSequence do
       end
     RUBY
   end
+
+  it 'does not register an offense for a `sequence` with non-symbol argment' do
+    expect_no_offenses(<<~RUBY)
+      FactoryBot.define do
+        sequence(id)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a `sequence` without argument' do
+    expect_no_offenses(<<~RUBY)
+      FactoryBot.define do
+        sequence
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a `sequence` with receiver' do
+    expect_no_offenses(<<~RUBY)
+      FactoryBot.define do
+        foo.sequence(:id)
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-factory_bot/issues/80

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
