### PR TITLE
Enable cop for pending rubocop-performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -135,6 +135,43 @@ Style/RedundantStringEscape:
 Style/ReturnNilInPredicateMethodDefinition:
   Enabled: true
 
+# Enable pending rubocop-performance cops.
+
+Performance/AncestorsInclude:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/CollectionLiteralInLoop:
+  Enabled: true
+Performance/ConstantRegexp:
+  Enabled: true
+Performance/MapCompact:
+  Enabled: true
+Performance/MapMethodChain:
+  Enabled: true
+Performance/MethodObjectAsBlock:
+  Enabled: true
+Performance/RedundantEqualityComparisonBlock:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantSplitRegexpArgument:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: true
+Performance/Squeeze:
+  Enabled: true
+Performance/StringIdentifierArgument:
+  Enabled: true
+Performance/StringInclude:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
+
 # Enable pending rubocop-rspec cops.
 
 RSpec/BeEmpty:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ spec_helper_glob =
 Dir
   .glob(File.expand_path(spec_helper_glob, __dir__))
   .sort
-  .each(&method(:require))
+  .each { |file| require file }
 
 RSpec.configure do |config|
   # Set metadata so smoke tests are run on all cop specs


### PR DESCRIPTION
```
❯ bundle exec rubocop
Inspecting 42 files
.......................................C..

Offenses:

spec/spec_helper.rb:17:9: C: Performance/MethodObjectAsBlock: Use block explicitly instead of block-passing a method object.
  .each(&method(:require))
        ^^^^^^^^^^^^^^^^^

42 files inspected, 1 offense detected
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
