### PR TITLE
Include `**/factories.rb` in the inspection target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Include `**/factories.rb` in the inspection target. ([@r7kamura])
+
 ## 2.25.1 (2024-01-08)
 
 - Fix a false positive for `FactoryBot/CreateList` when create call does have method calls and repeat multiple times with other argument. ([@ydah])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2,9 +2,8 @@
 FactoryBot:
   Enabled: true
   Include:
-    - "**/spec/factories.rb"
+    - "**/factories.rb"
     - "**/spec/factories/**/*.rb"
-    - "**/test/factories.rb"
     - "**/test/factories/**/*.rb"
     - "**/features/support/factories/**/*.rb"
   DocumentationBaseURL: https://docs.rubocop.org/rubocop-factory_bot


### PR DESCRIPTION
According to the factory_bot documentation, the default `FactoryBot.definition_file_paths` also includes `factories.rb`.

> The load order is controlled by the `FactoryBot.definition_file_paths` attribute. The default load order is:
> 
> 1. `factories.rb`
> 1. `test/factories.rb`
> 1. `test/factories/**/*.rb`
> 1. `spec/factories.rb`
> 1. `spec/factories/**/*.rb`

- https://github.com/thoughtbot/factory_bot/blob/cf3f21fcbbccbc40849c74a84eeb0bb0bd6c7606/docs/src/ref/find_definitions.md?plain=1#L9-L13

Therefore, it would be reasonable to include this file in the inspection target.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
