### PR TITLE
Fix `InternalAffairs/ExampleDescription`

### DIFF
--- a/spec/rubocop/cop/factory_bot/redundant_factory_option_spec.rb
+++ b/spec/rubocop/cop/factory_bot/redundant_factory_option_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::RedundantFactoryOption do
   end
 
   context 'when `association` has redundant factory option in Array' do
-    it 'registers no offense' do
+    it 'registers offense' do
       expect_offense(<<~RUBY)
         association :user, factory: %i[user]
                            ^^^^^^^^^^^^^^^^^ Remove redundant `factory` option.


### PR DESCRIPTION
https://github.com/rubocop/rubocop-factory_bot/actions/runs/8295790896/job/22703558438

```
Running RuboCop...
RuboCop failed!
Inspecting 42 files
...................................C......

Offenses:

spec/rubocop/cop/factory_bot/redundant_factory_option_spec.rb:[5](https://github.com/rubocop/rubocop-factory_bot/actions/runs/8295790896/job/22703558438#step:5:6)0:[8](https://github.com/rubocop/rubocop-factory_bot/actions/runs/8295790896/job/22703558438#step:5:9): C: [Correctable] InternalAffairs/ExampleDescription: Description does not match use of expect_offense.
    it 'registers no offense' do
       ^^^^^^^^^^^^^^^^^^^^^^

42 files inspected, 1 offense detected, 1 offense autocorrectable
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
