### PR TITLE
Fix some rubocop offenses

### DIFF
--- a/spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb
+++ b/spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
     end
 
     context 'when create and first argument are on same line' do
-      it 'register an offense' do
+      it 'registers an offense' do
         expect_offense(<<~RUBY)
           create(:user,
           ^^^^^^ Prefer method call without parentheses
@@ -459,7 +459,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
     let(:enforced_style) { :require_parentheses }
     let(:explicit_only) { false }
 
-    it 'register an offense when using `create` with an explicit receiver' do
+    it 'registers an offense when using `create` with an explicit receiver' do
       expect_offense(<<~RUBY)
         FactoryBot.create :user
                    ^^^^^^ Prefer method call with parentheses
@@ -470,7 +470,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
       RUBY
     end
 
-    it 'register an offense when using `create` with no explicit receiver' do
+    it 'registers an offense when using `create` with no explicit receiver' do
       expect_offense(<<~RUBY)
         create :user
         ^^^^^^ Prefer method call with parentheses
@@ -486,7 +486,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
     let(:enforced_style) { :require_parentheses }
     let(:explicit_only) { true }
 
-    it 'register an offense when using `create` with an explicit receiver' do
+    it 'registers an offense when using `create` with an explicit receiver' do
       expect_offense(<<~RUBY)
         FactoryBot.create :user
                    ^^^^^^ Prefer method call with parentheses


### PR DESCRIPTION
```
spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb:352:10: C: [Corrected] InternalAffairs/ExampleDescription: Description does not match use of expect_offense.
      it 'register an offense' do
         ^^^^^^^^^^^^^^^^^^^^^
spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb:462:8: C: [Corrected] InternalAffairs/ExampleDescription: Description does not match use of expect_offense.
    it 'register an offense when using `create` with an explicit receiver' do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb:473:8: C: [Corrected] InternalAffairs/ExampleDescription: Description does not match use of expect_offense.
    it 'register an offense when using `create` with no explicit receiver' do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb:489:8: C: [Corrected] InternalAffairs/ExampleDescription: Description does not match use of expect_offense.
    it 'register an offense when using `create` with an explicit receiver' do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
