### PR TITLE
Support `AutoCorrect: contextual` option for LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix a false positive for `FactoryBot/AssociationStyle` when using nested factories with traits. ([@jaydorsey])
+- Support `AutoCorrect: contextual` option for LSP. ([@ydah])
 
 ## 2.25.1 (2024-01-08)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -49,6 +49,7 @@ FactoryBot/ConsistentParenthesesStyle:
 FactoryBot/CreateList:
   Description: Checks for create_list usage.
   Enabled: true
+  AutoCorrect: contextual
   Include:
     - "**/*_spec.rb"
     - "**/spec/**/*"
@@ -61,7 +62,7 @@ FactoryBot/CreateList:
   ExplicitOnly: false
   SafeAutoCorrect: false
   VersionAdded: '1.25'
-  VersionChanged: '2.24'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/CreateList
 
 FactoryBot/ExcessiveCreateList:

--- a/docs/modules/ROOT/pages/cops_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_factorybot.adoc
@@ -255,9 +255,9 @@ build :user
 
 | Enabled
 | Yes
-| Always (Unsafe)
+| Command-line only (Unsafe)
 | 1.25
-| 2.24
+| <<next>>
 |===
 
 Checks for create_list usage.


### PR DESCRIPTION
Follow up: https://github.com/rubocop/rubocop-rspec/pull/1899

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
