### PR TITLE
`AutoCorrect: contextual` needs rubocop v1.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.26.1 (2024-06-12)
+
 - Bump RuboCop requirement to +1.61. ([@ydah])
 
 ## 2.26.0 (2024-06-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Bump RuboCop requirement to +1.61. ([@ydah])
+
 ## 2.26.0 (2024-06-08)
 
 - Fix a false positive for `FactoryBot/AssociationStyle` when using nested factories with traits. ([@jaydorsey])

--- a/lib/rubocop/factory_bot/version.rb
+++ b/lib/rubocop/factory_bot/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module FactoryBot
     # Version information for the factory_bot RuboCop plugin.
     module Version
-      STRING = '2.26.0'
+      STRING = '2.26.1'
     end
   end
 end

--- a/rubocop-factory_bot.gemspec
+++ b/rubocop-factory_bot.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.41'
+  spec.add_runtime_dependency 'rubocop', '~> 1.61'
 end


### PR DESCRIPTION
follow up: https://github.com/rubocop/rubocop-rspec/pull/1901

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
