### PR TITLE
Fix a rubocop offense

### DIFF
--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -38,7 +38,7 @@ namespace :cut_release do
   def add_header_to_changelog(version)
     update_file('CHANGELOG.md') do |changelog|
       changelog.sub("## Master (Unreleased)\n\n",
-                    '\0' "## #{version} (#{Time.now.strftime('%F')})\n\n")
+                    "\\0## #{version} (#{Time.now.strftime('%F')})\n\n")
     end
   end
 


### PR DESCRIPTION
This PR fixes rubocop offense

```
tasks/cut_release.rake:41:21: W: [Corrected] Lint/ImplicitStringConcatenation: Combine '\0' and "## #{version} (#{Time.now.strftime('%F')})\n\n" into a single string literal, rather than using implicit string concatenation. Or, if they were intended to be separate method arguments, separate them with a comma.
                    '\0' "## #{version} (#{Time.now.strftime('%F')})\n\n")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tasks/cut_release.rake:41:21: C: [Corrected] Style/StringConcatenation: Prefer string interpolation to string concatenation.
                    '\0' + "## #{version} (#{Time.now.strftime('%F')})\n\n")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
