### PR TITLE
Let ConsistentParenthesesStyle :omit_parentheses ignore trait + omitted hash value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix a false positive for `FactoryBot/ConsistentParenthesesStyle` when using traits and omitting hash values. ([@thejonroberts])
+
 ## 2.26.1 (2024-06-12)
 
 - Bump RuboCop requirement to +1.61. ([@ydah])
@@ -110,6 +112,7 @@
 [@seanpdoyle]: https://github.com/seanpdoyle
 [@tdeo]: https://github.com/tdeo
 [@tejasbubane]: https://github.com/tejasbubane
+[@thejonroberts]: https://github.com/thejonroberts
 [@vzvu3k6k]: https://github.com/vzvu3k6k
 [@walf443]: https://github.com/walf443
 [@ybiquitous]: https://github.com/ybiquitous

--- a/lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb
+++ b/lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb
@@ -79,7 +79,7 @@ module RuboCop
         def_node_matcher :omit_hash_value?, <<~PATTERN
           (send
             #factory_call? %FACTORY_CALLS
-            {sym str send lvar}
+            {sym str send lvar} _*
             (hash
               <value_omission? ...>
             )

--- a/spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb
+++ b/spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb
@@ -418,6 +418,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
         expect_no_offenses(<<~RUBY)
           create(:user, name:)
           create(:user, name:, client:)
+          create(:user, :trait, name:, client:)
         RUBY
       end
 
@@ -426,6 +427,8 @@ RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
         expect_no_offenses(<<~RUBY)
           create(:user, client:, name: 'foo')
           create(:user, client: 'foo', name:)
+          create(:user, :trait, client:, name: 'foo')
+          create(:user, :trait, client: 'foo', name:)
         RUBY
       end
 
@@ -434,10 +437,13 @@ RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
         expect_offense(<<~RUBY)
           create(:user, name: 'foo')
           ^^^^^^ Prefer method call without parentheses
+          create(:user, :trait, name: 'foo')
+          ^^^^^^ Prefer method call without parentheses
         RUBY
 
         expect_correction(<<~RUBY)
           create :user, name: 'foo'
+          create :user, :trait, name: 'foo'
         RUBY
       end
 
@@ -446,10 +452,13 @@ RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
         expect_offense(<<~RUBY)
           create(:user, foo(name:))
           ^^^^^^ Prefer method call without parentheses
+          create(:user, :trait, foo(name:))
+          ^^^^^^ Prefer method call without parentheses
         RUBY
 
         expect_correction(<<~RUBY)
           create :user, foo(name:)
+          create :user, :trait, foo(name:)
         RUBY
       end
     end


### PR DESCRIPTION
Fix #135 

When ConsistentParenthesesStyle is :omit_parentheses, we ignore factory calls that have an omitted hash value (ruby 3.1 shorthand syntax). Parentheses are required if the arguments end with the key of the omitted value. (e.g. `create(:user, name:)`)

However, if a trait was used, (e.g. `create(:user, :trait, name:)`) `omit_hash_value?` matcher did not match it, and thus it would be an offense and corrected to remove the parentheses - potentially causing a syntax error.

This change adds a wildcard to the `omit_hash_value?` matcher to allow any number of symbols at the start of the factory call (before the hash values).

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- ~~[ ] Updated documentation.~~
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).