### PR TITLE
Fix incorrect plugin version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix incorrect plugin version. ([@koic])
+
 ## 2.27.0 (2025-03-06)
 
 - Fix a false positive for `FactoryBot/ConsistentParenthesesStyle` when using traits and omitting hash values. ([@thejonroberts])
@@ -105,6 +107,7 @@
 [@jaydorsey]: https://github.com/jaydorsey
 [@jfragoulis]: https://github.com/jfragoulis
 [@jonatas]: https://github.com/jonatas
+[@koic]: https://github.com/koic
 [@leoarnold]: https://github.com/leoarnold
 [@liberatys]: https://github.com/Liberatys
 [@morissetcl]: https://github.com/morissetcl

--- a/lib/rubocop-factory_bot.rb
+++ b/lib/rubocop-factory_bot.rb
@@ -8,6 +8,7 @@ require 'rubocop'
 require_relative 'rubocop/factory_bot/factory_bot'
 require_relative 'rubocop/factory_bot/language'
 require_relative 'rubocop/factory_bot/plugin'
+require_relative 'rubocop/factory_bot/version'
 
 require_relative 'rubocop/cop/factory_bot/mixin/configurable_explicit_only'
 


### PR DESCRIPTION
`require_relative 'rubocop/factory_bot/version'` was missing, causing the constant lookup for `Version::STRING` in `lib/rubocop/factory_bot/plugin.rb` to resolve to `RuboCop::Version::STRING` instead of `RuboCop::FactoryBot::Version::STRING`.

This PR fixes an issue where `rubocop -V` incorrectly displayed the RuboCop version instead of the rubocop-factory_bot version:

```console
$ bundle exec rubocop -V
1.73.2 (using Parser 3.3.7.1, rubocop-ast 1.38.1, analyzing as Ruby 2.7, running on ruby 3.4.2) [x86_64-darwin23]
  - rubocop-performance 1.24.0
  - rubocop-rake 0.7.1
  - rubocop-capybara 1.73.2
  - rubocop-factory_bot 1.73.2
  - rubocop-rspec_rails 2.31.0
  - rubocop-rspec 3.5.0
```

**Replace this text with a summary of the changes in your PR. The more detailed you are, the better.**

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
