### PR TITLE
Remove prism skipped tests

### DIFF
--- a/spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb
+++ b/spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb
@@ -201,10 +201,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
     end
 
     %w[&& ||].each do |operator|
-      # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0.
-      # It has been resolved in the development line.
-      # This will be resolved in Prism > 0.24.0 and higher releases.
-      context "with #{operator}", broken_on: :prism do
+      context "with #{operator}" do
         it 'does not flag the call' do
           expect_no_offenses(<<~RUBY)
             can_create_user? #{operator} create(:user)
@@ -213,10 +210,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
       end
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0.
-    # It has been resolved in the development line.
-    # This will be resolved in Prism > 0.24.0 and higher releases.
-    context 'with ternary operator', broken_on: :prism do
+    context 'with ternary operator' do
       it 'does not flag the call' do
         expect_no_offenses(<<~RUBY)
           can_create_user? ? create(:user) : nil


### PR DESCRIPTION
These probably pass for a while now already.

No more `broken_on: :prism` in the RuboCop org when this and https://github.com/rubocop/rubocop-ast/pull/372 are merged