### PR TITLE
Fix an error for `FactoryBot/AssociationStyle` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 2.27.1 (2025-03-12)
 
 - Fix incorrect plugin version. ([@koic])
+- Fix an error for `FactoryBot/AssociationStyle` cop when `trait` is not inside `factory` block. ([@viralpraxis])
 
 ## 2.27.0 (2025-03-06)
 
@@ -121,6 +122,7 @@
 [@tdeo]: https://github.com/tdeo
 [@tejasbubane]: https://github.com/tejasbubane
 [@thejonroberts]: https://github.com/thejonroberts
+[@viralpraxis]: https://github.com/viralpraxis
 [@vzvu3k6k]: https://github.com/vzvu3k6k
 [@walf443]: https://github.com/walf443
 [@ybiquitous]: https://github.com/ybiquitous

--- a/lib/rubocop/cop/factory_bot/association_style.rb
+++ b/lib/rubocop/cop/factory_bot/association_style.rb
@@ -175,7 +175,9 @@ module RuboCop
         def bad?(node)
           if style == :explicit
             implicit_association?(node) &&
-              !trait_within_trait?(node)
+              (factory_node = trait_factory_node(node)) && !trait_within_trait?(
+                node, factory_node
+              )
           else
             explicit_association?(node) &&
               !with_strategy_build_option?(node) &&
@@ -247,12 +249,14 @@ module RuboCop
           options
         end
 
-        def trait_within_trait?(node)
-          factory_node = node.ancestors.reverse.find do |ancestor|
+        def trait_within_trait?(node, factory_node)
+          trait_name(factory_node).include?(node.method_name)
+        end
+
+        def trait_factory_node(node)
+          node.ancestors.reverse.find do |ancestor|
             ancestor.method?(:factory) if ancestor.block_type?
           end
-
-          trait_name(factory_node).include?(node.method_name)
         end
       end
     end

--- a/spec/rubocop/cop/factory_bot/association_style_spec.rb
+++ b/spec/rubocop/cop/factory_bot/association_style_spec.rb
@@ -315,6 +315,14 @@ RSpec.describe RuboCop::Cop::FactoryBot::AssociationStyle do
     end
 
     context 'when implicit association is called in trait block' do
+      it 'does not register an offense for `trait` without `factory` block' do
+        expect_no_offenses(<<~RUBY)
+          trait :with_user do
+            user
+          end
+        RUBY
+      end
+
       it 'registers and corrects an offense' do
         expect_offense(<<~RUBY)
           factory :article do


### PR DESCRIPTION
```shell
  1) RuboCop::Cop::FactoryBot::AssociationStyle when EnforcedStyle is :explicit when implicit association is called in trait block does not register an offense for `trait` without `factory` block
     Failure/Error:
       def autocorrect(corrector, node)
         if style == :explicit
           autocorrect_to_explicit_style(corrector, node)
         else
           autocorrect_to_implicit_style(corrector, node)
         end

     NoMethodError:
       undefined method 'each_node' for nil
     # ./lib/rubocop/cop/factory_bot/association_style.rb:149:in 'RuboCop::Cop::FactoryBot::AssociationStyle#trait_name'
     # ./lib/rubocop/cop/factory_bot/association_style.rb:254:in 'Enumerator#each'
     # ./lib/rubocop/cop/factory_bot/association_style.rb:254:in 'Enumerable#include?'
     # ./lib/rubocop/cop/factory_bot/association_style.rb:254:in 'RuboCop::Cop::FactoryBot::AssociationStyle#trait_within_trait?'
     # ./lib/rubocop/cop/factory_bot/association_style.rb:179:in 'RuboCop::Cop::FactoryBot::AssociationStyle#bad?'
     # ./lib/rubocop/cop/factory_bot/association_style.rb:201:in 'block in RuboCop::Cop::FactoryBot::AssociationStyle#bad_associations_in'
     # ./lib/rubocop/cop/factory_bot/association_style.rb:200:in 'Array#select'
     # ./lib/rubocop/cop/factory_bot/association_style.rb:200:in 'RuboCop::Cop::FactoryBot::AssociationStyle#bad_associations_in'
     # ./lib/rubocop/cop/factory_bot/association_style.rb:84:in 'RuboCop::Cop::FactoryBot::AssociationStyle#on_send'
     # ./spec/rubocop/cop/factory_bot/association_style_spec.rb:319:in 'block (4 levels) in <top (required)>'
```

**Replace this text with a summary of the changes in your PR. The more detailed you are, the better.**

______________________________________________________________________

- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Squashed related commits together.
- [X] Added tests.
- [X] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [X] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
