### PR TITLE
Fix an error for `FactoryBot/ConsistentParenthesesStyle` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Master (Unreleased)
 
+- Fix an error for `FactoryBot/AssociationStyle` cop when `trait` is not inside `factory` block. ([@viralpraxis])
+- Fix an error for `FactoryBot/ConsistentParenthesesStyle` cop when using keyword splat argument. ([@viralpraxis])
+
 ## 2.27.1 (2025-03-12)
 
 - Fix incorrect plugin version. ([@koic])
-- Fix an error for `FactoryBot/AssociationStyle` cop when `trait` is not inside `factory` block. ([@viralpraxis])
 
 ## 2.27.0 (2025-03-06)
 

--- a/lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb
+++ b/lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb
@@ -81,7 +81,7 @@ module RuboCop
             #factory_call? %FACTORY_CALLS
             {sym str send lvar} _*
             (hash
-              <value_omission? ...>
+              <[!kwsplat value_omission?] ...>
             )
           )
         PATTERN

--- a/spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb
+++ b/spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb
@@ -456,6 +456,20 @@ RSpec.describe RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle do
         RUBY
       end
     end
+
+    it 'registers an offense with `splat`' do
+      expect_offense(<<~RUBY)
+        build(:user, :trait, *args)
+        ^^^^^ Prefer method call without parentheses
+      RUBY
+    end
+
+    it 'registers an offense with `kwsplat` node argument' do
+      expect_offense(<<~RUBY)
+        build(:user, :trait, foo: :bar, **kwargs)
+        ^^^^^ Prefer method call without parentheses
+      RUBY
+    end
   end
 
   context 'when ExplicitOnly is false' do


### PR DESCRIPTION
```
  1) RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle when EnforcedStyle is :omit_parentheses registers an offense with `kwsplat` node argument
     Failure/Error: factory_call(node) { register_offense(node) }

     NoMethodError:
       undefined method 'value_omission?' for an instance of RuboCop::AST::KeywordSplatNode
     # ./lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb:96:in 'block in RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle#omit_hash_value?'
     # ./lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb:94:in 'RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle#omit_hash_value?'
     # ./lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb:111:in 'RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle#register_offense_with_parentheses'
     # ./lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb:104:in 'RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle#register_offense'
     # ./lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb:96:in 'block in RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle#on_send'
     # ./lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb:83:in 'RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle#factory_call'
     # ./lib/rubocop/cop/factory_bot/consistent_parentheses_style.rb:96:in 'RuboCop::Cop::FactoryBot::ConsistentParenthesesStyle#on_send'
     # ./spec/rubocop/cop/factory_bot/consistent_parentheses_style_spec.rb:468:in 'block (3 levels) in <top (required)>'
```

**Replace this text with a summary of the changes in your PR. The more detailed you are, the better.**

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Squashed related commits together.
- [X] Added tests.
- [X] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [X] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

