### PR TITLE
CI: Use latest Ruby where possible

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "4.0"
+          ruby-version: ruby
       - name: Run Danger
         run: bundle exec danger
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0"
+          ruby-version: ruby
           bundler-cache: true
       - run: bundle exec rake confirm_config documentation_syntax_check confirm_documentation
 
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0"
+          ruby-version: ruby
           bundler-cache: true
       - run: bundle exec rake spec
 
@@ -74,7 +74,7 @@ jobs:
           echo "gem 'rubocop', github: 'rubocop/rubocop'" > Gemfile.local
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0"
+          ruby-version: ruby
           bundler-cache: true
       - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
 


### PR DESCRIPTION
By always using the latest stable Ruby version, the CI configuration will require less updating when a new Ruby version is released.