### PR TITLE
Load cops lazily

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,7 @@ Layout/LineLength:
   Max: 80 # default: 120
   AllowedPatterns:
     - '^\s*# .*https?:\/\/.+\[.+\]\.?$' # Allow long asciidoc links
+    - '^\s*register_cop :' # Cop registrations in the department module
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Add autocorrect for `FactoryBot/FactoryAssociationWithStrategy` cop. ([@r7kamura])
+- Speed up loading rubocop-factory_bot by lazily loading only the cops needed for a run. This requires RuboCop 1.89.0+. ([@bquorning])
 
 ## 2.28.0 (2025-11-12)
 

--- a/Rakefile
+++ b/Rakefile
@@ -96,9 +96,7 @@ task :new_cop, [:cop] do |_task, args|
   generator = RuboCop::FactoryBot::Cop::Generator.new(cop_name)
   generator.write_source
   generator.write_spec
-  generator.inject_require(
-    root_file_path: 'lib/rubocop/cop/factory_bot_cops.rb'
-  )
+  generator.inject_registration
   generator.inject_config
 
   puts generator.todo

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -14,7 +14,7 @@ Use the bundled rake task `new_cop` to generate a cop template:
 $ bundle exec rake 'new_cop[FactoryBot/CopName]'
 [create] lib/rubocop/cop/factory_bot/cop_name.rb
 [create] spec/rubocop/cop/factory_bot/cop_name_spec.rb
-[modify] lib/rubocop/cop/factory_bot_cops.rb - `require_relative 'factory_bot/cop_name'` was injected.
+[modify] lib/rubocop/cop/factory_bot.rb - `register_cop :CopName, "#{__dir__}/factory_bot/cop_name"` was injected.
 [modify] A configuration for the cop is added into config/default.yml.
 Do 4 steps:
   1. Modify the description of FactoryBot/CopName in config/default.yml

--- a/lib/rubocop-factory_bot.rb
+++ b/lib/rubocop-factory_bot.rb
@@ -12,4 +12,4 @@ require_relative 'rubocop/factory_bot/version'
 
 require_relative 'rubocop/cop/factory_bot/mixin/configurable_explicit_only'
 
-require_relative 'rubocop/cop/factory_bot_cops'
+require_relative 'rubocop/cop/factory_bot'

--- a/lib/rubocop/cop/factory_bot.rb
+++ b/lib/rubocop/cop/factory_bot.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Cops for the `FactoryBot` department. The department's cops are
+    # registered for lazy loading and their files are loaded on demand.
+    module FactoryBot
+      extend LazyLoader
+
+      register_cop :AssociationStyle, "#{__dir__}/factory_bot/association_style"
+      register_cop :AttributeDefinedStatically, "#{__dir__}/factory_bot/attribute_defined_statically"
+      register_cop :ConsistentParenthesesStyle, "#{__dir__}/factory_bot/consistent_parentheses_style"
+      register_cop :CreateList, "#{__dir__}/factory_bot/create_list"
+      register_cop :ExcessiveCreateList, "#{__dir__}/factory_bot/excessive_create_list"
+      register_cop :FactoryAssociationWithStrategy, "#{__dir__}/factory_bot/factory_association_with_strategy"
+      register_cop :FactoryClassName, "#{__dir__}/factory_bot/factory_class_name"
+      register_cop :FactoryNameStyle, "#{__dir__}/factory_bot/factory_name_style"
+      register_cop :IdSequence, "#{__dir__}/factory_bot/id_sequence"
+      register_cop :RedundantFactoryOption, "#{__dir__}/factory_bot/redundant_factory_option"
+      register_cop :SyntaxMethods, "#{__dir__}/factory_bot/syntax_methods"
+    end
+  end
+end

--- a/lib/rubocop/cop/factory_bot_cops.rb
+++ b/lib/rubocop/cop/factory_bot_cops.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'factory_bot/association_style'
-require_relative 'factory_bot/attribute_defined_statically'
-require_relative 'factory_bot/consistent_parentheses_style'
-require_relative 'factory_bot/create_list'
-require_relative 'factory_bot/excessive_create_list'
-require_relative 'factory_bot/factory_association_with_strategy'
-require_relative 'factory_bot/factory_class_name'
-require_relative 'factory_bot/factory_name_style'
-require_relative 'factory_bot/id_sequence'
-require_relative 'factory_bot/redundant_factory_option'
-require_relative 'factory_bot/syntax_methods'
+# @deprecated This file is deprecated. Cops are registered for lazy loading in
+#   `rubocop/cop/factory_bot`; this file is kept for compatibility with code
+#   that requires it directly.
+require_relative 'factory_bot'

--- a/rubocop-factory_bot.gemspec
+++ b/rubocop-factory_bot.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'lint_roller', '~> 1.1'
-  spec.add_dependency 'rubocop', '~> 1.72', '>= 1.72.1'
+  spec.add_dependency 'rubocop', '~> 1.89'
 end

--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -12,13 +12,7 @@ RSpec.describe 'config/default.yml' do
   end
 
   let(:cop_names) do
-    glob = SpecHelper::ROOT.join('lib', 'rubocop', 'cop', 'factory_bot', '*.rb')
-    Pathname.glob(glob).map do |file|
-      file_name = file.basename('.rb').to_s
-      cop_name  = file_name.gsub(/(^|_)(.)/) { Regexp.last_match(2).upcase }
-      namespace = namespaces[file.dirname.basename.to_s]
-      "#{namespace}/#{cop_name}"
-    end
+    RuboCop::Cop::Registry.global.names.grep(%r{\AFactoryBot/})
   end
 
   let(:config_keys) do

--- a/spec/project/lazy_loading_spec.rb
+++ b/spec/project/lazy_loading_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'English'
+
+RSpec.describe 'cop lazy loading' do
+  def run_script(source)
+    Dir.mktmpdir do |dir|
+      script = File.join(dir, 'script.rb')
+      File.write(script, source)
+      lib = File.expand_path('../../lib', __dir__)
+      output = `#{RbConfig.ruby} -I #{lib} #{script} 2>&1`
+      raise "script failed:\n#{output}" unless $CHILD_STATUS.success?
+
+      output
+    end
+  end
+
+  it 'registers every cop file in `lib/rubocop/cop/factory_bot` exactly once' do
+    cop_root = File.expand_path('../../lib/rubocop/cop', __dir__)
+    files = Dir[File.join(cop_root, 'factory_bot', '*.rb')].sort
+
+    department = RuboCop::Cop::Registry.global.cops_for_department(:FactoryBot)
+    registered = department.map do |cop|
+      Object.const_source_location(cop.name).first
+    end
+
+    expect(registered.sort).to eq(files)
+  end
+
+  it 'registers all cops without loading their files' do
+    output = run_script(<<~RUBY)
+      require 'rubocop-factory_bot'
+
+      registry = RuboCop::Cop::Registry.global
+      loaded = $LOADED_FEATURES.grep(%r{/rubocop/cop/factory_bot/(?!mixin/)})
+
+      puts "registered=\#{registry.names.grep(%r{\\AFactoryBot/}).size}"
+      puts "loaded_cop_files=\#{loaded.size}"
+    RUBY
+
+    expect(output).to include('registered=11', 'loaded_cop_files=0')
+  end
+
+  it 'does not register a cop twice when its file is required directly' do
+    output = run_script(<<~RUBY)
+      require 'rubocop-factory_bot'
+
+      before = RuboCop::Cop::Registry.global.length
+      require 'rubocop/cop/factory_bot/create_list'
+      after = RuboCop::Cop::Registry.global.length
+
+      puts "stable=\#{before == after}"
+      puts "class=\#{RuboCop::Cop::Registry.global.find_by_cop_name('FactoryBot/CreateList')}"
+    RUBY
+
+    expect(output).to include('stable=true', 'class=RuboCop::Cop::FactoryBot::CreateList')
+  end
+end


### PR DESCRIPTION
## Summary

- Follow-up to rubocop/rubocop-rspec#2215, rubocop/rubocop-capybara#224, and rubocop/rubocop-rspec_rails#115.
- Replace the eager `require_relative` calls in `lib/rubocop/cop/factory_bot_cops.rb` with a `FactoryBot` department module (`lib/rubocop/cop/factory_bot.rb`) that registers every cop with the global registry through `RuboCop::Cop::LazyLoader#register_cop`, without loading the cop files. A cop's file is loaded only when the cop class is needed, which for an inspection run means only the enabled cops. This requires RuboCop 1.89.0+.
- `lib/rubocop/cop/factory_bot_cops.rb` is kept as a deprecated compatibility shim for code that requires it directly.
- The `new_cop` rake task switches from `inject_require` to `inject_registration`, and the development documentation is updated accordingly.
- Added `spec/project/lazy_loading_spec.rb`, asserting that every cop file is registered exactly once, that no cop files load merely by requiring `rubocop-factory_bot`, and that requiring a cop file directly does not register it twice.

## Test plan

- [x] `bundle exec rake spec` passes (319 examples, 0 failures).
- [x] `bundle exec rake internal_investigation` reports no offenses.
- [x] `bundle exec rake confirm_config` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)