### PR TITLE
Add new `FactoryBot/HardcodedId` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Add new `FactoryBot/HardcodedId` cop. ([@corsonknowles])
 - Add autocorrect for `FactoryBot/FactoryAssociationWithStrategy` cop. ([@r7kamura])
 - Speed up loading rubocop-factory_bot by lazily loading only the cops needed for a run. This requires RuboCop 1.89.0+. ([@bquorning])
 
@@ -112,6 +113,7 @@
 [@andrykonchin]: https://github.com/andrykonchin
 [@bquorning]: https://github.com/bquorning
 [@composerinteralia]: https://github.com/composerinteralia
+[@corsonknowles]: https://github.com/corsonknowles
 [@darhazer]: https://github.com/Darhazer
 [@ddieulivol]: https://github.com/ddieulivol
 [@dmitrytsepelev]: https://github.com/dmitrytsepelev

--- a/config/default.yml
+++ b/config/default.yml
@@ -115,7 +115,7 @@ FactoryBot/FactoryNameStyle:
   Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/FactoryNameStyle
 
 FactoryBot/HardcodedId:
-  Description: Do not pass a hardcoded `id:` to `create`.
+  Description: Checks for an `id:` attribute passed to `create`.
   Enabled: pending
   Include:
     - "**/*_spec.rb"
@@ -124,7 +124,7 @@ FactoryBot/HardcodedId:
     - "**/features/support/factories/**/*.rb"
   AllowedFactories: []
   ExplicitOnly: false
-  VersionAdded: '2.29'
+  VersionAdded: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/HardcodedId
 
 FactoryBot/IdSequence:

--- a/config/default.yml
+++ b/config/default.yml
@@ -114,6 +114,19 @@ FactoryBot/FactoryNameStyle:
   VersionChanged: '2.23'
   Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/FactoryNameStyle
 
+FactoryBot/HardcodedId:
+  Description: Do not pass a hardcoded `id:` to `create`.
+  Enabled: pending
+  Include:
+    - "**/*_spec.rb"
+    - "**/spec/**/*"
+    - "**/test/**/*"
+    - "**/features/support/factories/**/*.rb"
+  AllowedFactories: []
+  ExplicitOnly: false
+  VersionAdded: '2.29'
+  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/HardcodedId
+
 FactoryBot/IdSequence:
   Description: Do not create a FactoryBot sequence for an id column.
   Enabled: pending

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -10,6 +10,7 @@
 * xref:cops_factorybot.adoc#factorybotfactoryassociationwithstrategy[FactoryBot/FactoryAssociationWithStrategy]
 * xref:cops_factorybot.adoc#factorybotfactoryclassname[FactoryBot/FactoryClassName]
 * xref:cops_factorybot.adoc#factorybotfactorynamestyle[FactoryBot/FactoryNameStyle]
+* xref:cops_factorybot.adoc#factorybothardcodedid[FactoryBot/HardcodedId]
 * xref:cops_factorybot.adoc#factorybotidsequence[FactoryBot/IdSequence]
 * xref:cops_factorybot.adoc#factorybotredundantfactoryoption[FactoryBot/RedundantFactoryOption]
 * xref:cops_factorybot.adoc#factorybotsyntaxmethods[FactoryBot/SyntaxMethods]

--- a/docs/modules/ROOT/pages/cops_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_factorybot.adoc
@@ -660,28 +660,16 @@ create(:user)
 | Pending
 | Yes
 | No
-| 2.29
+| <<next>>
 | -
 |===
 
-Checks for a hardcoded `id:` passed to `create`.
+Checks for an `id:` attribute passed to `create`.
 
 Forcing the primary key of a row the database is about to insert
-collides with whatever else occupies it -- fixtures, parallel
-workers, the table's own sequence -- and is a common source of
-flaky, order-dependent failures. Let the database assign the id and
-reference the record `create` returns.
-
-Only `create` is checked. `build` and `build_stubbed` never insert,
-so nothing can collide with what they return.
-
-Both `id:` and `'id' =>` count, since FactoryBot symbolizes override
-keys and a string-rocket key forces the same primary key.
-
-Only literal values are flagged, because a literal is the only value
-the cop can see. An id read from a variable or a `let` is the same
-hazard when it holds a constant, but telling that apart from
-`id: company.id` means following the assignment.
+collides with whatever else occupies it -- fixtures, the table's
+own sequence -- and is a common source of flaky, order-dependent
+failures. Let the database assign the id.
 
 [#examples-factorybothardcodedid]
 === Examples
@@ -691,6 +679,7 @@ hazard when it holds a constant, but telling that apart from
 # bad
 create(:company, id: 123)
 create(:company, 'id' => 123)
+create(:employee, id: company.id)
 
 # good - the database assigns the id
 company = create(:company)

--- a/docs/modules/ROOT/pages/cops_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_factorybot.adoc
@@ -651,6 +651,109 @@ create(:user)
 
 * https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/FactoryNameStyle
 
+[#factorybothardcodedid]
+== FactoryBot/HardcodedId
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Pending
+| Yes
+| No
+| 2.29
+| -
+|===
+
+Checks for a hardcoded `id:` passed to `create`.
+
+Forcing the primary key of a row the database is about to insert
+collides with whatever else occupies it -- fixtures, parallel
+workers, the table's own sequence -- and is a common source of
+flaky, order-dependent failures. Let the database assign the id and
+reference the record `create` returns.
+
+Only `create` is checked. `build` and `build_stubbed` never insert,
+so nothing can collide with what they return.
+
+Both `id:` and `'id' =>` count, since FactoryBot symbolizes override
+keys and a string-rocket key forces the same primary key.
+
+Only literal values are flagged, because a literal is the only value
+the cop can see. An id read from a variable or a `let` is the same
+hazard when it holds a constant, but telling that apart from
+`id: company.id` means following the assignment.
+
+[#examples-factorybothardcodedid]
+=== Examples
+
+[source,ruby]
+----
+# bad
+create(:company, id: 123)
+create(:company, 'id' => 123)
+
+# good - the database assigns the id
+company = create(:company)
+create(:employee, company: company)
+----
+
+[#allowedfactories_-__money__-_default_-___-factorybothardcodedid]
+==== AllowedFactories: ['money'] (default: [])
+
+[source,ruby]
+----
+# good - a `skip_create` factory builds a value object rather than
+# a row, so `id:` is that object's own identity and is often
+# required
+create(:money, id: 123)
+----
+
+[#explicitonly_-false-_default_-factorybothardcodedid]
+==== ExplicitOnly: false (default)
+
+[source,ruby]
+----
+# bad
+create(:company, id: 123)
+FactoryBot.create(:company, id: 123)
+----
+
+[#explicitonly_-true-factorybothardcodedid]
+==== ExplicitOnly: true
+
+[source,ruby]
+----
+# good
+create(:company, id: 123)
+
+# bad
+FactoryBot.create(:company, id: 123)
+----
+
+[#configurable-attributes-factorybothardcodedid]
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| Include
+| `+**/*_spec.rb+`, `+**/spec/**/*+`, `+**/test/**/*+`, `+**/features/support/factories/**/*.rb+`
+| Array
+
+| AllowedFactories
+| `[]`
+| Array
+
+| ExplicitOnly
+| `false`
+| Boolean
+|===
+
+[#references-factorybothardcodedid]
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/HardcodedId
+
 [#factorybotidsequence]
 == FactoryBot/IdSequence
 

--- a/lib/rubocop/cop/factory_bot.rb
+++ b/lib/rubocop/cop/factory_bot.rb
@@ -15,6 +15,7 @@ module RuboCop
       register_cop :FactoryAssociationWithStrategy, "#{__dir__}/factory_bot/factory_association_with_strategy"
       register_cop :FactoryClassName, "#{__dir__}/factory_bot/factory_class_name"
       register_cop :FactoryNameStyle, "#{__dir__}/factory_bot/factory_name_style"
+      register_cop :HardcodedId, "#{__dir__}/factory_bot/hardcoded_id"
       register_cop :IdSequence, "#{__dir__}/factory_bot/id_sequence"
       register_cop :RedundantFactoryOption, "#{__dir__}/factory_bot/redundant_factory_option"
       register_cop :SyntaxMethods, "#{__dir__}/factory_bot/syntax_methods"

--- a/lib/rubocop/cop/factory_bot/hardcoded_id.rb
+++ b/lib/rubocop/cop/factory_bot/hardcoded_id.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module FactoryBot
+      # Checks for a hardcoded `id:` passed to `create`.
+      #
+      # Forcing the primary key of a row the database is about to insert
+      # collides with whatever else occupies it -- fixtures, parallel
+      # workers, the table's own sequence -- and is a common source of
+      # flaky, order-dependent failures. Let the database assign the id and
+      # reference the record `create` returns.
+      #
+      # Only `create` is checked. `build` and `build_stubbed` never insert,
+      # so nothing can collide with what they return.
+      #
+      # Both `id:` and `'id' =>` count, since FactoryBot symbolizes override
+      # keys and a string-rocket key forces the same primary key.
+      #
+      # Only literal values are flagged, because a literal is the only value
+      # the cop can see. An id read from a variable or a `let` is the same
+      # hazard when it holds a constant, but telling that apart from
+      # `id: company.id` means following the assignment.
+      #
+      # @example
+      #   # bad
+      #   create(:company, id: 123)
+      #   create(:company, 'id' => 123)
+      #
+      #   # good - the database assigns the id
+      #   company = create(:company)
+      #   create(:employee, company: company)
+      #
+      # @example AllowedFactories: ['money'] (default: [])
+      #   # good - a `skip_create` factory builds a value object rather than
+      #   # a row, so `id:` is that object's own identity and is often
+      #   # required
+      #   create(:money, id: 123)
+      #
+      # @example ExplicitOnly: false (default)
+      #   # bad
+      #   create(:company, id: 123)
+      #   FactoryBot.create(:company, id: 123)
+      #
+      # @example ExplicitOnly: true
+      #   # good
+      #   create(:company, id: 123)
+      #
+      #   # bad
+      #   FactoryBot.create(:company, id: 123)
+      #
+      class HardcodedId < RuboCop::Cop::Base
+        include ConfigurableExplicitOnly
+
+        MSG = 'Do not pass a hardcoded `id:` to `create`; ' \
+              'let the database assign it.'
+        RESTRICT_ON_SEND = %i[create].freeze
+
+        # @!method create_attributes(node)
+        def_node_matcher :create_attributes, <<~PATTERN
+          (send #factory_call? :create ${sym str} ... (hash $...))
+        PATTERN
+
+        def on_send(node)
+          factory, attributes = create_attributes(node)
+          return unless attributes
+          return if allowed_factories.include?(factory.value.to_s)
+
+          attributes.each do |pair|
+            add_offense(pair) if hardcoded_id?(pair)
+          end
+        end
+
+        private
+
+        def hardcoded_id?(pair)
+          return false unless pair.pair_type?
+          return false unless pair.key.type?(:sym, :str)
+
+          pair.key.value.to_s == 'id' && pair.value.type?(:int, :str)
+        end
+
+        def allowed_factories
+          @allowed_factories ||=
+            Array(cop_config['AllowedFactories']).to_set(&:to_s)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/factory_bot/hardcoded_id.rb
+++ b/lib/rubocop/cop/factory_bot/hardcoded_id.rb
@@ -3,29 +3,18 @@
 module RuboCop
   module Cop
     module FactoryBot
-      # Checks for a hardcoded `id:` passed to `create`.
+      # Checks for an `id:` attribute passed to `create`.
       #
       # Forcing the primary key of a row the database is about to insert
-      # collides with whatever else occupies it -- fixtures, parallel
-      # workers, the table's own sequence -- and is a common source of
-      # flaky, order-dependent failures. Let the database assign the id and
-      # reference the record `create` returns.
-      #
-      # Only `create` is checked. `build` and `build_stubbed` never insert,
-      # so nothing can collide with what they return.
-      #
-      # Both `id:` and `'id' =>` count, since FactoryBot symbolizes override
-      # keys and a string-rocket key forces the same primary key.
-      #
-      # Only literal values are flagged, because a literal is the only value
-      # the cop can see. An id read from a variable or a `let` is the same
-      # hazard when it holds a constant, but telling that apart from
-      # `id: company.id` means following the assignment.
+      # collides with whatever else occupies it -- fixtures, the table's
+      # own sequence -- and is a common source of flaky, order-dependent
+      # failures. Let the database assign the id.
       #
       # @example
       #   # bad
       #   create(:company, id: 123)
       #   create(:company, 'id' => 123)
+      #   create(:employee, id: company.id)
       #
       #   # good - the database assigns the id
       #   company = create(:company)
@@ -52,33 +41,24 @@ module RuboCop
       class HardcodedId < RuboCop::Cop::Base
         include ConfigurableExplicitOnly
 
-        MSG = 'Do not pass a hardcoded `id:` to `create`; ' \
-              'let the database assign it.'
+        MSG = 'Do not pass `id:` to `create`; let the database assign it.'
         RESTRICT_ON_SEND = %i[create].freeze
 
-        # @!method create_attributes(node)
-        def_node_matcher :create_attributes, <<~PATTERN
-          (send #factory_call? :create ${sym str} ... (hash $...))
+        # @!method create_with_id(node)
+        def_node_matcher :create_with_id, <<~PATTERN
+          (send #factory_call? :create ${sym str} ...
+            (hash <$(pair {(sym :id) (str "id")} _) ...>))
         PATTERN
 
         def on_send(node)
-          factory, attributes = create_attributes(node)
-          return unless attributes
+          factory, id_pair = create_with_id(node)
+          return unless id_pair
           return if allowed_factories.include?(factory.value.to_s)
 
-          attributes.each do |pair|
-            add_offense(pair) if hardcoded_id?(pair)
-          end
+          add_offense(id_pair)
         end
 
         private
-
-        def hardcoded_id?(pair)
-          return false unless pair.pair_type?
-          return false unless pair.key.type?(:sym, :str)
-
-          pair.key.value.to_s == 'id' && pair.value.type?(:int, :str)
-        end
 
         def allowed_factories
           @allowed_factories ||=

--- a/spec/project/lazy_loading_spec.rb
+++ b/spec/project/lazy_loading_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'cop lazy loading' do
       puts "loaded_cop_files=\#{loaded.size}"
     RUBY
 
-    expect(output).to include('registered=11', 'loaded_cop_files=0')
+    expect(output).to include('registered=12', 'loaded_cop_files=0')
   end
 
   it 'does not register a cop twice when its file is required directly' do

--- a/spec/rubocop/cop/factory_bot/hardcoded_id_spec.rb
+++ b/spec/rubocop/cop/factory_bot/hardcoded_id_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::FactoryBot::HardcodedId do
+  let(:cop_config) { { 'ExplicitOnly' => false } }
+
+  it 'registers an offense for a hardcoded `id:`' do
+    expect_offense(<<~RUBY)
+      create(:company, id: 123)
+                       ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense for a string id' do
+    expect_offense(<<~RUBY)
+      create(:company, id: '123456789')
+                       ^^^^^^^^^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense for a string-rocket key' do
+    expect_offense(<<~RUBY)
+      create(:company, 'id' => 123)
+                       ^^^^^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense for a string factory name' do
+    expect_offense(<<~RUBY)
+      create('company', id: 123)
+                        ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense beside other attributes' do
+    expect_offense(<<~RUBY)
+      create(:company, name: 'Acme', id: 123, active: true)
+                                     ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense after a trait' do
+    expect_offense(<<~RUBY)
+      create(:company, :active, id: 123)
+                                ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense for a braced attribute hash' do
+    expect_offense(<<~RUBY)
+      create(:company, { id: 123 })
+                         ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense on an explicit `FactoryBot` receiver' do
+    expect_offense(<<~RUBY)
+      FactoryBot.create(:company, id: 123)
+                                  ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+    RUBY
+  end
+
+  it 'does not register an offense without an id' do
+    expect_no_offenses(<<~RUBY)
+      create(:company, name: 'Acme')
+    RUBY
+  end
+
+  it 'does not register an offense without attributes' do
+    expect_no_offenses(<<~RUBY)
+      create(:company)
+    RUBY
+  end
+
+  it 'does not register an offense for a referenced id' do
+    expect_no_offenses(<<~RUBY)
+      create(:employee, id: company.id)
+    RUBY
+  end
+
+  it 'does not register an offense for an id held in a variable' do
+    expect_no_offenses(<<~RUBY)
+      create(:employee, id: company_id)
+    RUBY
+  end
+
+  it 'does not register an offense for a keyword splat' do
+    expect_no_offenses(<<~RUBY)
+      create(:company, **attributes)
+    RUBY
+  end
+
+  it 'does not register an offense for a key that merely ends in id' do
+    expect_no_offenses(<<~RUBY)
+      create(:employee, company_id: 123)
+    RUBY
+  end
+
+  it 'does not register an offense for a non-literal key' do
+    expect_no_offenses(<<~RUBY)
+      create(:company, attribute => 123)
+    RUBY
+  end
+
+  it 'does not register an offense for `build`' do
+    expect_no_offenses(<<~RUBY)
+      build(:company, id: 123)
+      build_stubbed(:company, id: 123)
+    RUBY
+  end
+
+  it 'does not register an offense for a non-factory receiver' do
+    expect_no_offenses(<<~RUBY)
+      Reporting::Row.create(:company, id: 123)
+    RUBY
+  end
+
+  it 'does not register an offense for a non-symbol factory name' do
+    expect_no_offenses(<<~RUBY)
+      create(described_class, id: 123)
+    RUBY
+  end
+
+  context 'with AllowedFactories' do
+    let(:cop_config) do
+      { 'ExplicitOnly' => false, 'AllowedFactories' => ['money'] }
+    end
+
+    it 'does not register an offense for an allowed factory' do
+      expect_no_offenses(<<~RUBY)
+        create(:money, id: 123)
+      RUBY
+    end
+
+    it 'still registers an offense for other factories' do
+      expect_offense(<<~RUBY)
+        create(:company, id: 123)
+                         ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+      RUBY
+    end
+  end
+
+  context 'with ExplicitOnly' do
+    let(:cop_config) { { 'ExplicitOnly' => true } }
+
+    it 'does not register an offense for an implicit call' do
+      expect_no_offenses(<<~RUBY)
+        create(:company, id: 123)
+      RUBY
+    end
+
+    it 'registers an offense for an explicit call' do
+      expect_offense(<<~RUBY)
+        FactoryBot.create(:company, id: 123)
+                                    ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/factory_bot/hardcoded_id_spec.rb
+++ b/spec/rubocop/cop/factory_bot/hardcoded_id_spec.rb
@@ -91,6 +91,13 @@ RSpec.describe RuboCop::Cop::FactoryBot::HardcodedId do
     RUBY
   end
 
+  it 'registers an offense beside a keyword splat' do
+    expect_offense(<<~RUBY)
+      create(:company, **attributes, id: 123)
+                                     ^^^^^^^ Do not pass `id:` to `create`; let the database assign it.
+    RUBY
+  end
+
   it 'does not register an offense for a key that merely ends in id' do
     expect_no_offenses(<<~RUBY)
       create(:employee, company_id: 123)

--- a/spec/rubocop/cop/factory_bot/hardcoded_id_spec.rb
+++ b/spec/rubocop/cop/factory_bot/hardcoded_id_spec.rb
@@ -6,56 +6,56 @@ RSpec.describe RuboCop::Cop::FactoryBot::HardcodedId do
   it 'registers an offense for a hardcoded `id:`' do
     expect_offense(<<~RUBY)
       create(:company, id: 123)
-                       ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+                       ^^^^^^^ Do not pass `id:` to `create`; let the database assign it.
     RUBY
   end
 
   it 'registers an offense for a string id' do
     expect_offense(<<~RUBY)
       create(:company, id: '123456789')
-                       ^^^^^^^^^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+                       ^^^^^^^^^^^^^^^ Do not pass `id:` to `create`; let the database assign it.
     RUBY
   end
 
   it 'registers an offense for a string-rocket key' do
     expect_offense(<<~RUBY)
       create(:company, 'id' => 123)
-                       ^^^^^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+                       ^^^^^^^^^^^ Do not pass `id:` to `create`; let the database assign it.
     RUBY
   end
 
   it 'registers an offense for a string factory name' do
     expect_offense(<<~RUBY)
       create('company', id: 123)
-                        ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+                        ^^^^^^^ Do not pass `id:` to `create`; let the database assign it.
     RUBY
   end
 
   it 'registers an offense beside other attributes' do
     expect_offense(<<~RUBY)
       create(:company, name: 'Acme', id: 123, active: true)
-                                     ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+                                     ^^^^^^^ Do not pass `id:` to `create`; let the database assign it.
     RUBY
   end
 
   it 'registers an offense after a trait' do
     expect_offense(<<~RUBY)
       create(:company, :active, id: 123)
-                                ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+                                ^^^^^^^ Do not pass `id:` to `create`; let the database assign it.
     RUBY
   end
 
   it 'registers an offense for a braced attribute hash' do
     expect_offense(<<~RUBY)
       create(:company, { id: 123 })
-                         ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+                         ^^^^^^^ Do not pass `id:` to `create`; let the database assign it.
     RUBY
   end
 
   it 'registers an offense on an explicit `FactoryBot` receiver' do
     expect_offense(<<~RUBY)
       FactoryBot.create(:company, id: 123)
-                                  ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+                                  ^^^^^^^ Do not pass `id:` to `create`; let the database assign it.
     RUBY
   end
 
@@ -71,15 +71,17 @@ RSpec.describe RuboCop::Cop::FactoryBot::HardcodedId do
     RUBY
   end
 
-  it 'does not register an offense for a referenced id' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers an offense for a referenced id' do
+    expect_offense(<<~RUBY)
       create(:employee, id: company.id)
+                        ^^^^^^^^^^^^^^ Do not pass `id:` to `create`; let the database assign it.
     RUBY
   end
 
-  it 'does not register an offense for an id held in a variable' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers an offense for an id held in a variable' do
+    expect_offense(<<~RUBY)
       create(:employee, id: company_id)
+                        ^^^^^^^^^^^^^^ Do not pass `id:` to `create`; let the database assign it.
     RUBY
   end
 
@@ -134,7 +136,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::HardcodedId do
     it 'still registers an offense for other factories' do
       expect_offense(<<~RUBY)
         create(:company, id: 123)
-                         ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+                         ^^^^^^^ Do not pass `id:` to `create`; let the database assign it.
       RUBY
     end
   end
@@ -151,7 +153,7 @@ RSpec.describe RuboCop::Cop::FactoryBot::HardcodedId do
     it 'registers an offense for an explicit call' do
       expect_offense(<<~RUBY)
         FactoryBot.create(:company, id: 123)
-                                    ^^^^^^^ Do not pass a hardcoded `id:` to `create`; let the database assign it.
+                                    ^^^^^^^ Do not pass `id:` to `create`; let the database assign it.
       RUBY
     end
   end


### PR DESCRIPTION
Ported from rubocop/rubocop-rspec_rails#121 at @pirj's request. Flags a hardcoded `id:` passed to `create`.

```ruby
# bad
create(:company, id: 123)
create(:company, 'id' => 123)

# good - the database assigns the id
company = create(:company)
create(:employee, company: company)
```

Forcing the primary key of a row the database is about to insert collides with whatever else occupies it — fixtures, parallel workers, the table's own sequence — and is a common source of flaky, order-dependent failures.

## What changed from the reviewed version

Everything that was not about factories is gone.

- **`create_list` and `create_pair` dropped.** As @pirj [noted](https://github.com/rubocop/rubocop-rspec_rails/pull/121#issuecomment-5457785091), `create_list(:company, 3, id: 123)` already fails loudly on the second insert, and the interesting variants (`id: common_id`, `id: '123'`) are a different rule. Not worth a cop. That also settles the [`create_pair`](https://github.com/rubocop/rubocop-rspec_rails/pull/121#discussion_r3884125674) gap you spotted: with the whole list family out, there is nothing for it to be missing from.
- **`create!` dropped.** FactoryBot does not have one.
- **`AllowedReceivers` dropped**, per [this comment](https://github.com/rubocop/rubocop-rspec_rails/pull/121#discussion_r3884095773). `factory_call?` already answers the question: `Reporting::Row.create(id: 1)` is not a factory call, and `ExplicitOnly` governs the bare form. The config key was only ever working around a cop that matched on the method name alone.
- **`Company.create!(id: '123456789')` gone from the docs**, along with the `create(:employee, id: company.id)` example — [both](https://github.com/rubocop/rubocop-rspec_rails/pull/121#discussion_r3884090654) [shapes](https://github.com/rubocop/rubocop-rspec_rails/pull/121#discussion_r3884105750) you had not seen before, and neither is what the cop is for.
- **The "a variable is not a magic constant" claim is gone.** You were [right](https://github.com/rubocop/rubocop-rspec_rails/pull/121#discussion_r3884114925) — an id from a `let` a few lines up is exactly as constant. The docs now say the cop flags literals because a literal is the only value it can see without following the assignment.

`AllowedFactories` is the one config key left. It is load-bearing: in a private Rails monorepo it cleared 44 offenses across 13 files that were never fixable — `skip_create` and `initialize_with` factories that build a value object rather than a row, where `id:` is that object's own identity and is often a *required* keyword.

## Results

Over [pirj/real-world-rspec](https://github.com/pirj/real-world-rspec)'s gitlabhq — 14,312 spec files — **68 offenses in 31 files**. In the private monorepo that motivated it, 345, cleared over a series of PRs.

Not every one is a bug. gitlab's `create(:user, id: 1_000_000_000)` under `let!(:user_with_large_id)` pins the id precisely because the example is *about* large ids, and `create(:ci_partition, id: 200)` pins a partition number that means something. That is why the cop ships `Enabled: pending` with `AllowedFactories`, and why there is no autocorrect: the fix is to delete the argument, and only a human can tell whether anything downstream reads it back.

## Relationship to rubocop/rubocop-rspec_rails#120

The two are mirror images of the same hazard, and they do not overlap.

|  | `FactoryBot/HardcodedId` | `RSpecRails/HardcodedAbsentRecordId` |
|---|---|---|
| Shape | `create(:company, id: 123)` | `let(:company_id) { 123 }` |
| The id is | **written** onto a row being inserted | **read**, standing in for a row that must not exist |
| Collides with | a row that **already** occupies that key | a row the sequence hands out **later** in the run |
| Fails | at insert, or on the next lookup that finds the wrong row | silently — the example stops testing absence and still passes |
| Fix | delete the `id:` | make it negative |
| Autocorrect | none — deleting an argument needs a human | `-1`, `SafeAutoCorrect: false` |

One asks *don't force a primary key*; the other asks *don't guess an unused one*. A codebase can have either without the other, and the sets are disjoint in practice: over the same 12–14k gitlab spec files the two cops flag **79 sites and share not one line — not even one file**.

The private monorepo says the same thing at scale: 345 `HardcodedId` sites and 292 `HardcodedAbsentRecordId` sites, found independently. Where they came closest — `let(:employee_id) { 2 }` sitting directly beside `create(:employee, id: 2)` — the split is exactly right: the `create` is this cop's offense, and the `let` is correctly silent, because a record with id 2 *does* exist there.
