### PR TITLE
Bump ydah/mdformat-action from v1.0.0 to v1.0.1

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Mdformat
-        uses: ydah/mdformat-action@19c467fb015bb66f35abe33327e7a15c552877bc # v1.0.0
+        uses: ydah/mdformat-action@f15b43346e95022e0728b75ac90142f5db3c4016 # v1.0.1
         with:
           number: true
         env:


### PR DESCRIPTION
Update `ydah/mdformat-action` from `v1.0.0` to `v1.0.1`.

This release moves the Docker image from Debian Bullseye to Bookworm and removes the APT operations that prevented the action image from building. `actionlint .github/workflows/linting.yml` passes.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests. Not applicable; this only updates a workflow dependency.
- [ ] Updated documentation. Not applicable; no documentation changed.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes. Not applicable; no code behavior changed.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit). Not run; this only updates a workflow dependency.
